### PR TITLE
Add KVO and Combine support to documentation and test

### DIFF
--- a/Foil.xcodeproj/project.pbxproj
+++ b/Foil.xcodeproj/project.pbxproj
@@ -462,6 +462,7 @@
 				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = Tests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -471,6 +472,8 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				"PROVISIONING_PROFILE_SPECIFIER[sdk=macosx*]" = "";
+				TVOS_DEPLOYMENT_TARGET = 13.0;
+				WATCHOS_DEPLOYMENT_TARGET = 6.0;
 			};
 			name = Debug;
 		};
@@ -483,6 +486,7 @@
 				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = Tests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -492,6 +496,8 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				"PROVISIONING_PROFILE_SPECIFIER[sdk=macosx*]" = "";
+				TVOS_DEPLOYMENT_TARGET = 13.0;
+				WATCHOS_DEPLOYMENT_TARGET = 6.0;
 			};
 			name = Release;
 		};

--- a/README.md
+++ b/README.md
@@ -67,6 +67,29 @@ extension WrappedDefaultOptional {
 }
 ```
 
+### Observing with Combine
+
+To support KVO monitoring via Combine, use the `NSObject.KeyValueObservingPublisher` helpers [provided by Apple](https://developer.apple.com/documentation/combine/performing-key-value-observing-with-combine). This requires your object to inherit from `NSObject` and adding `@objc dynamic` to the properties you would like to observe:
+
+```swift
+final class AppSettings: NSObject {
+    static let shared = AppSettings()
+
+    @WrappedDefaultOptional(keyName: "nickname")
+    @objc dynamic var nickname: String?
+}
+
+// Usage
+
+AppSettings.shared
+    .publisher(for: \.nickname, options: [.new])
+    .sink { print($0) }
+    .store(in: &cancellable)
+
+AppSettings.shared.nickname = "abc123"
+// prints "abc123" from `.sink`
+```
+
 ### Supported types
 
 The following types are supported by default for use with `@WrappedDefault`.

--- a/Tests/TestSettings.swift
+++ b/Tests/TestSettings.swift
@@ -20,7 +20,7 @@ enum TestFruit: String, UserDefaultsSerializable {
     case banana
 }
 
-final class TestSettings {
+final class TestSettings: NSObject {
 
     static var store = UserDefaults.testSuite()
 
@@ -59,4 +59,7 @@ final class TestSettings {
 
     @WrappedDefault(keyName: "fruit", defaultValue: .apple, userDefaults: store)
     var fruit: TestFruit
+
+    @WrappedDefaultOptional(keyName: "nickname", userDefaults: store)
+    @objc dynamic var nickname: String?
 }


### PR DESCRIPTION
Issue #4  

Documents how `Foil` can be used with native KVO and Combine support provided by Apple out of the box.