### PR TITLE
Correct cast in test assertion to data type

### DIFF
--- a/Tests/IntegrationTests.swift
+++ b/Tests/IntegrationTests.swift
@@ -97,7 +97,7 @@ final class IntegrationTests: XCTestCase {
         XCTAssertEqual(TestSettings.store.fetch("data"), newValue)
 
         settings.data = nil
-        XCTAssertNil(TestSettings.store.fetchOptional("data") as URL?)
+        XCTAssertNil(TestSettings.store.fetchOptional("data") as Data?)
     }
 
     func test_Integration_Array() {


### PR DESCRIPTION
Assertion will always be `nil` since casting to the incorrect type. Fixed typo and casting correctly to `Data?`.