### PR TITLE
Custom RawRepresentable support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ NEXT
 
 - TBA
 
+1.1.0
+-----
+
+This release closes the [1.1.0 milestone](https://github.com/jessesquires/Foil/milestone/1?closed=1).
+
+- Updated documentation with examples for observing changes in defaults ([#4](https://github.com/jessesquires/Foil/issues/4), [#5](https://github.com/jessesquires/Foil/pull/5), [@basememara](https://github.com/basememara))
+
+- Various documentation and internal library improvements ([@jessesquires](https://github.com/jessesquires))
+
 1.0.0
 -----
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ NEXT
 
 This release closes the [1.1.0 milestone](https://github.com/jessesquires/Foil/milestone/1?closed=1).
 
+- Added support for custom `RawRepresentable` types ([#10](https://github.com/jessesquires/Foil/pull/10), [@basememara](https://github.com/basememara))
+
 - Updated documentation with examples for observing changes in defaults ([#4](https://github.com/jessesquires/Foil/issues/4), [#5](https://github.com/jessesquires/Foil/pull/5), [@basememara](https://github.com/basememara))
 
 - Various documentation and internal library improvements ([@jessesquires](https://github.com/jessesquires))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,8 @@ NEXT
 
 This release closes the [1.1.0 milestone](https://github.com/jessesquires/Foil/milestone/1?closed=1).
 
-<<<<<<< HEAD
 - Added support for custom `RawRepresentable` types ([#10](https://github.com/jessesquires/Foil/pull/10), [@basememara](https://github.com/basememara))
 
-=======
->>>>>>> main
 - Updated documentation with examples for observing changes in defaults ([#4](https://github.com/jessesquires/Foil/issues/4), [#5](https://github.com/jessesquires/Foil/pull/5), [@basememara](https://github.com/basememara))
 
 - Various documentation and internal library improvements ([@jessesquires](https://github.com/jessesquires))

--- a/Sources/UserDefaultsSerializable.swift
+++ b/Sources/UserDefaultsSerializable.swift
@@ -148,10 +148,10 @@ extension Dictionary: UserDefaultsSerializable where Key == String, Value: UserD
 }
 
 /// :nodoc:
-extension UserDefaultsSerializable where Self: RawRepresentable {
-    public var storedValue: RawValue { self.rawValue }
+extension UserDefaultsSerializable where Self: RawRepresentable, Self.RawValue: UserDefaultsSerializable {
+    public var storedValue: RawValue.StoredValue { self.rawValue.storedValue }
 
-    public init(storedValue: RawValue) {
-        self = Self(rawValue: storedValue)!
+    public init(storedValue: RawValue.StoredValue) {
+        self = Self(rawValue: Self.RawValue(storedValue: storedValue))!
     }
 }

--- a/Tests/IntegrationTests.swift
+++ b/Tests/IntegrationTests.swift
@@ -136,6 +136,22 @@ final class IntegrationTests: XCTestCase {
         XCTAssertEqual(TestSettings.store.fetch("fruit"), newValue)
     }
 
+    func test_Integration_Custom_RawRepresentable() {
+        let defaultValue = settings.customRawRepresented
+        XCTAssert(defaultValue.rawValue.isEmpty)
+
+        var newValue = TestFruit.apple
+        settings.customRawRepresented[.key1] = newValue
+        XCTAssertEqual(settings.customRawRepresented[.key1], newValue)
+
+        newValue = TestFruit.orange
+        settings.customRawRepresented[.key2] = newValue
+        XCTAssertEqual(settings.customRawRepresented[.key2], newValue)
+
+        let expectedValue = ["key1": TestFruit.apple.rawValue, "key2": TestFruit.orange.rawValue]
+        XCTAssertEqual(TestSettings.store.fetch("customRawRepresented"), expectedValue)
+    }
+
     func test_Integration_Publisher() {
         let promise = expectation(description: #function)
         var publishedValue: String?

--- a/Tests/TestSettings.swift
+++ b/Tests/TestSettings.swift
@@ -20,6 +20,23 @@ enum TestFruit: String, UserDefaultsSerializable {
     case banana
 }
 
+struct TestCustomRepresented: RawRepresentable, UserDefaultsSerializable {
+    enum Key: String {
+        case key1, key2, key3
+    }
+
+    var rawValue: [String: TestFruit]
+
+    init(rawValue: [String: TestFruit]) {
+        self.rawValue = rawValue
+    }
+
+    subscript(_ key: Key) -> TestFruit? {
+        get { rawValue[key.rawValue] }
+        set { rawValue[key.rawValue] = newValue }
+    }
+}
+
 final class TestSettings: NSObject {
 
     static var store = UserDefaults.testSuite()
@@ -59,6 +76,9 @@ final class TestSettings: NSObject {
 
     @WrappedDefault(keyName: "fruit", defaultValue: .apple, userDefaults: store)
     var fruit: TestFruit
+
+    @WrappedDefault(keyName: "customRawRepresented", defaultValue: TestCustomRepresented(rawValue: [:]), userDefaults: store)
+    var customRawRepresented: TestCustomRepresented
 
     @WrappedDefaultOptional(keyName: "nickname", userDefaults: store)
     @objc dynamic var nickname: String?


### PR DESCRIPTION
I ran into a situation where the compiler allowed me to implement a custom `RawRepresentable` type but crashed at runtime:

```swift
struct TestCustomRepresented: RawRepresentable, UserDefaultsSerializable {
    var rawValue: [String: TestFruit]

    init(rawValue: [String: TestFruit]) {
        self.rawValue = rawValue
    }
}

final class TestSettings {
    @WrappedDefaultOptional(keyName: "customRawRepresented", userDefaults: store)
    var customRawRepresented: TestCustomRepresented?
}
```

When I ran this and tried saving a value to it, I got this crash:

```swift
settings.customRawRepresented = TestCustomRepresented(rawValue: ["key1": .apple])

// =>

libc++abi: terminating with uncaught exception of type NSException
*** Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: 'Attempt to insert non-property list object {
    key1 = "FoilTests.TestFruit.apple";
} for key customRawRepresented'
terminating with uncaught exception of type NSException
```

What I ended up doing is fine-tuning the conditional bounds for `Self.RawValue` conformance of `RawRepresentable` and adjusting the implementation:

```swift
// From this:
extension UserDefaultsSerializable where Self: RawRepresentable {
    public var storedValue: RawValue { self.rawValue }

    public init(storedValue: RawValue) {
        self = Self(rawValue: storedValue)!
    }
}

// To this:
extension UserDefaultsSerializable where Self: RawRepresentable, Self.RawValue: UserDefaultsSerializable {
    public var storedValue: RawValue.StoredValue { self.rawValue.storedValue }

    public init(storedValue: RawValue.StoredValue) {
        self = Self(rawValue: Self.RawValue(storedValue: storedValue))!
    }
}
```

This makes sense to leverage `RawRepresentable` this way since according to the [docs](https://developer.apple.com/documentation/swift/rawrepresentable), `RawRepresentable` was designed to interoperate with legacy systems, which `UserDefaults` could be considered:

> Using the raw value of a conforming type streamlines interoperation with Objective-C and legacy APIs..

Doing this opened some interesting doors to `UserDefaults` while allowing existing `RawRepresentable` conformers to remain unchanged:

```swift
struct TestCustomRepresented: RawRepresentable, UserDefaultsSerializable {
    var rawValue: [String: TestFruit]

    init(rawValue: [String: TestFruit]) {
        self.rawValue = rawValue
    }
}

extension TestCustomRepresented {
    enum Key: String {
        case key1, key2, key3
    }

    subscript(_ key: Key) -> TestFruit? {
        get { rawValue[key.rawValue] }
        set { rawValue[key.rawValue] = newValue }
    }
}

settings.customRawRepresented[.key2] = .orange
```