### PR TITLE
Add default support for `UInt`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ This release closes the [1.1.0 milestone](https://github.com/jessesquires/Foil/m
 
 - Added support for custom `RawRepresentable` types ([#10](https://github.com/jessesquires/Foil/pull/10), [@basememara](https://github.com/basememara))
 
-- Add default support for `UInt` types ([#3](https://github.com/jessesquires/Foil/issues/3), [#12](https://github.com/jessesquires/Foil/pull/12), [@jessesquires](https://github.com/jessesquires))
+- Add default support for `UInt` ([#3](https://github.com/jessesquires/Foil/issues/3), [#12](https://github.com/jessesquires/Foil/pull/12), [@jessesquires](https://github.com/jessesquires))
 
 - Updated documentation with examples for observing changes in defaults ([#4](https://github.com/jessesquires/Foil/issues/4), [#5](https://github.com/jessesquires/Foil/pull/5), [@basememara](https://github.com/basememara))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,13 +12,15 @@ NEXT
 
 This release closes the [1.1.0 milestone](https://github.com/jessesquires/Foil/milestone/1?closed=1).
 
-- Updated documentation with examples for observing changes in defaults ([#4](https://github.com/jessesquires/Foil/issues/4), [#5](https://github.com/jessesquires/Foil/pull/5), [@basememara](https://github.com/basememara))
+- Add default support for `UInt` types ([#3](https://github.com/jessesquires/Foil/issues/3), [#12](https://github.com/jessesquires/Foil/pull/12), [@jessesquires](https://github.com/jessesquires))
 
-- Various documentation and internal library improvements ([@jessesquires](https://github.com/jessesquires))
+- Updated documentation with examples for observing changes in defaults when using Foil ([#4](https://github.com/jessesquires/Foil/issues/4), [#5](https://github.com/jessesquires/Foil/pull/5), [@basememara](https://github.com/basememara))
+
+- Minor documentation and internal library improvements ([@jessesquires](https://github.com/jessesquires))
 
 1.0.0
 -----
 
-Initial release. 🎉 
+Initial release. 🎉
 
 [Documentation available here](https://jessesquires.github.io/Foil/).

--- a/Sources/UserDefaultsSerializable.swift
+++ b/Sources/UserDefaultsSerializable.swift
@@ -61,6 +61,15 @@ extension Int: UserDefaultsSerializable {
 }
 
 /// :nodoc:
+extension UInt: UserDefaultsSerializable {
+    public var storedValue: Self { self }
+
+    public init(storedValue: Self) {
+        self = storedValue
+    }
+}
+
+/// :nodoc:
 extension Float: UserDefaultsSerializable {
     public var storedValue: Self { self }
 

--- a/Tests/IntegrationTests.swift
+++ b/Tests/IntegrationTests.swift
@@ -37,6 +37,15 @@ final class IntegrationTests: XCTestCase {
         XCTAssertEqual(TestSettings.store.fetch("count"), newValue)
     }
 
+    func test_Integration_UInt() {
+        let defaultValue = settings.max
+        XCTAssertEqual(defaultValue, 42)
+
+        let newValue = UInt(666)
+        settings.max = newValue
+        XCTAssertEqual(TestSettings.store.fetch("max"), newValue)
+    }
+
     func test_Integration_Float() {
         let defaultValue = settings.mean
         XCTAssertEqual(defaultValue, 4.2)

--- a/Tests/TestSettings.swift
+++ b/Tests/TestSettings.swift
@@ -30,6 +30,9 @@ final class TestSettings: NSObject {
     @WrappedDefault(keyName: "count", defaultValue: 42, userDefaults: store)
     var count: Int
 
+    @WrappedDefault(keyName: "max", defaultValue: 42, userDefaults: store)
+    var max: UInt
+
     @WrappedDefault(keyName: "mean", defaultValue: 4.2, userDefaults: store)
     var mean: Float
 

--- a/Tests/WrappedDefaultTests.swift
+++ b/Tests/WrappedDefaultTests.swift
@@ -56,6 +56,20 @@ final class WrappedDefaultTests: XCTestCase {
         XCTAssertEqual(model.wrappedValue, newValue)
     }
 
+    func test_WrappedValue_UInt() {
+        let key = "key_\(#function)"
+        let defaultValue = UInt(42)
+        var model = WrappedDefault(keyName: key, defaultValue: defaultValue, userDefaults: testDefaults)
+
+        XCTAssertEqual(testDefaults.fetch(key), defaultValue)
+        XCTAssertEqual(model.wrappedValue, defaultValue)
+
+        let newValue = UInt(666)
+        model.wrappedValue = newValue
+        XCTAssertEqual(testDefaults.fetch(key), newValue)
+        XCTAssertEqual(model.wrappedValue, newValue)
+    }
+
     func test_WrappedValue_Float() {
         let key = "key_\(#function)"
         let defaultValue = Float(42.0)


### PR DESCRIPTION
Adds default conformance to `UserDefaultsSerializable` for `UInt`

See #3.
