### PR TITLE
Fix deployment targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,9 @@ NEXT
 
 This release closes the [1.2.0 milestone](https://github.com/jessesquires/Foil/milestone/2?closed=1).
 
-- Fix deployment target inconsistencies between CocoaPods and SwiftPM. ([#18](https://github.com/jessesquires/Foil/issues/18), [@kambala-decapitator](https://github.com/kambala-decapitator), [@jessesquires](https://github.com/jessesquires))
+- Fix deployment target inconsistencies between CocoaPods and SwiftPM. ([#18](https://github.com/jessesquires/Foil/issues/18), [#19](https://github.com/jessesquires/Foil/pull/19), [@kambala-decapitator](https://github.com/kambala-decapitator), [@jessesquires](https://github.com/jessesquires))
 
-- Lower deployment targets to support iOS/tvOS 9.0 and above. ([#16](https://github.com/jessesquires/Foil/issues/16), [@kambala-decapitator](https://github.com/kambala-decapitator), [@jessesquires](https://github.com/jessesquires))
+- Lower deployment targets to support iOS/tvOS 9.0 and above. ([#16](https://github.com/jessesquires/Foil/issues/16), [#19](https://github.com/jessesquires/Foil/pull/19), [@kambala-decapitator](https://github.com/kambala-decapitator), [@jessesquires](https://github.com/jessesquires))
 
 1.1.0
 -----

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ NEXT
 
 - TBA
 
+1.2.0
+-----
+
+This release closes the [1.2.0 milestone](https://github.com/jessesquires/Foil/milestone/2?closed=1).
+
+- Fix deployment target inconsistencies between CocoaPods and SwiftPM. ([#18](https://github.com/jessesquires/Foil/issues/18), [@kambala-decapitator](https://github.com/kambala-decapitator), [@jessesquires](https://github.com/jessesquires))
+
+- Lower deployment targets to support iOS/tvOS 9.0 and above. ([#16](https://github.com/jessesquires/Foil/issues/16), [@kambala-decapitator](https://github.com/kambala-decapitator), [@jessesquires](https://github.com/jessesquires))
+
 1.1.0
 -----
 

--- a/Foil.podspec
+++ b/Foil.podspec
@@ -14,8 +14,8 @@ Pod::Spec.new do |s|
 
    s.swift_version = '5.3'
 
-   s.ios.deployment_target = '12.0'
-   s.tvos.deployment_target = '12.0'
+   s.ios.deployment_target = '9.0'
+   s.tvos.deployment_target = '9.0'
    s.watchos.deployment_target = '5.0'
    s.osx.deployment_target = '10.13'
 

--- a/Foil.xcodeproj/project.pbxproj
+++ b/Foil.xcodeproj/project.pbxproj
@@ -466,11 +466,13 @@
 				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = Tests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
+				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				"PROVISIONING_PROFILE_SPECIFIER[sdk=macosx*]" = "";
@@ -486,11 +488,13 @@
 				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = Tests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
+				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				"PROVISIONING_PROFILE_SPECIFIER[sdk=macosx*]" = "";

--- a/Foil.xcodeproj/project.pbxproj
+++ b/Foil.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		0BA3823F2602C498005D7B2E /* IntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BA3823E2602C498005D7B2E /* IntegrationTests.swift */; };
 		0BA382422602C4D2005D7B2E /* TestSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BA382372602C1A7005D7B2E /* TestSettings.swift */; };
+		0BC99BA8266C27AE009B8CD4 /* ObservationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BC99BA7266C27AE009B8CD4 /* ObservationTests.swift */; };
 		0BEEA2B22603F8390035387F /* WrappedDefaultOptional.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BEEA2B12603F8390035387F /* WrappedDefaultOptional.swift */; };
 		0BEEA2BC260403560035387F /* UserDefaults+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BEEA2BB260403560035387F /* UserDefaults+Extensions.swift */; };
 		0BF54A8A25BF589E008484F8 /* Foil.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0BF54A8025BF589E008484F8 /* Foil.framework */; };
@@ -31,6 +32,7 @@
 /* Begin PBXFileReference section */
 		0BA382372602C1A7005D7B2E /* TestSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestSettings.swift; sourceTree = "<group>"; };
 		0BA3823E2602C498005D7B2E /* IntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntegrationTests.swift; sourceTree = "<group>"; };
+		0BC99BA7266C27AE009B8CD4 /* ObservationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObservationTests.swift; sourceTree = "<group>"; };
 		0BEEA2B12603F8390035387F /* WrappedDefaultOptional.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WrappedDefaultOptional.swift; sourceTree = "<group>"; };
 		0BEEA2BB260403560035387F /* UserDefaults+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserDefaults+Extensions.swift"; sourceTree = "<group>"; };
 		0BF54A8025BF589E008484F8 /* Foil.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Foil.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -97,6 +99,7 @@
 			children = (
 				0BF54A9025BF589E008484F8 /* Info.plist */,
 				0BA3823E2602C498005D7B2E /* IntegrationTests.swift */,
+				0BC99BA7266C27AE009B8CD4 /* ObservationTests.swift */,
 				0BA382372602C1A7005D7B2E /* TestSettings.swift */,
 				0BEEA2BB260403560035387F /* UserDefaults+Extensions.swift */,
 				0BF54A8E25BF589E008484F8 /* WrappedDefaultTests.swift */,
@@ -246,6 +249,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				0BC99BA8266C27AE009B8CD4 /* ObservationTests.swift in Sources */,
 				0BA382422602C4D2005D7B2E /* TestSettings.swift in Sources */,
 				0BF54A8F25BF589E008484F8 /* WrappedDefaultTests.swift in Sources */,
 				0BA3823F2602C498005D7B2E /* IntegrationTests.swift in Sources */,
@@ -316,7 +320,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				MACOSX_DEPLOYMENT_TARGET = 10.13;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
@@ -327,7 +331,7 @@
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2,3,4,6";
-				TVOS_DEPLOYMENT_TARGET = 12.0;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 				WATCHOS_DEPLOYMENT_TARGET = 5.0;
@@ -380,7 +384,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				MACOSX_DEPLOYMENT_TARGET = 10.13;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
@@ -390,7 +394,7 @@
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2,3,4,6";
-				TVOS_DEPLOYMENT_TARGET = 12.0;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
 				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -462,18 +466,14 @@
 				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = Tests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				"PROVISIONING_PROFILE_SPECIFIER[sdk=macosx*]" = "";
-				TVOS_DEPLOYMENT_TARGET = 13.0;
-				WATCHOS_DEPLOYMENT_TARGET = 6.0;
 			};
 			name = Debug;
 		};
@@ -486,18 +486,14 @@
 				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = Tests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				"PROVISIONING_PROFILE_SPECIFIER[sdk=macosx*]" = "";
-				TVOS_DEPLOYMENT_TARGET = 13.0;
-				WATCHOS_DEPLOYMENT_TARGET = 6.0;
 			};
 			name = Release;
 		};

--- a/Package.swift
+++ b/Package.swift
@@ -20,8 +20,10 @@ import PackageDescription
 let package = Package(
     name: "Foil",
     platforms: [
-        .iOS(.v13),
-        .macOS(.v10_15)
+        .iOS(.v9),
+        .tvOS(.v9),
+        .watchOS(.v5),
+        .macOS(.v10_13)
     ],
     products: [
         .library(

--- a/README.md
+++ b/README.md
@@ -119,8 +119,8 @@ Adding support for custom types is possible by conforming to `UserDefaultsSerial
 
 ## Supported Platforms
 
-- iOS 12.0+
-- tvOS 12.0+
+- iOS 9.0+
+- tvOS 9.0+
 - watchOS 5.0+
 - macOS 10.13+
 

--- a/Tests/IntegrationTests.swift
+++ b/Tests/IntegrationTests.swift
@@ -11,14 +11,12 @@
 //  Copyright © 2021-present Jesse Squires
 //
 
-import Combine
 @testable import Foil
 import XCTest
 
 final class IntegrationTests: XCTestCase {
 
     let settings = TestSettings()
-    var cancellable = Set<AnyCancellable>()
 
     func test_Integration_Bool() {
         let defaultValue = settings.flag
@@ -159,23 +157,5 @@ final class IntegrationTests: XCTestCase {
 
         let expectedValue = ["key1": TestFruit.apple.rawValue, "key2": TestFruit.orange.rawValue]
         XCTAssertEqual(TestSettings.store.fetch("customRawRepresented"), expectedValue)
-    }
-
-    func test_Integration_Publisher() {
-        let promise = expectation(description: #function)
-        var publishedValue: String?
-
-        settings
-            .publisher(for: \.nickname, options: [.new])
-            .sink {
-                publishedValue = $0
-                promise.fulfill()
-            }
-            .store(in: &cancellable)
-
-        settings.nickname = "abc123"
-        wait(for: [promise], timeout: 5)
-
-        XCTAssertEqual(settings.nickname, publishedValue)
     }
 }

--- a/Tests/ObservationTests.swift
+++ b/Tests/ObservationTests.swift
@@ -1,0 +1,41 @@
+//
+//  Created by Jesse Squires
+//  https://www.jessesquires.com
+//
+//  Documentation
+//  https://jessesquires.github.io/Foil
+//
+//  GitHub
+//  https://github.com/jessesquires/Foil
+//
+//  Copyright © 2021-present Jesse Squires
+//
+
+import Combine
+@testable import Foil
+import XCTest
+
+@available(iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+final class ObservationTests: XCTestCase {
+
+    let settings = TestSettings()
+    var cancellable = Set<AnyCancellable>()
+
+    func test_Integration_Publisher() {
+        let promise = expectation(description: #function)
+        var publishedValue: String?
+
+        settings
+            .publisher(for: \.nickname, options: [.new])
+            .sink {
+                publishedValue = $0
+                promise.fulfill()
+            }
+            .store(in: &cancellable)
+
+        settings.nickname = "abc123"
+        wait(for: [promise], timeout: 5)
+
+        XCTAssertEqual(settings.nickname, publishedValue)
+    }
+}

--- a/Tests/ObservationTests.swift
+++ b/Tests/ObservationTests.swift
@@ -11,10 +11,7 @@
 //  Copyright © 2021-present Jesse Squires
 //
 
-#if canImport(Combine)
 import Combine
-#endif
-
 @testable import Foil
 import XCTest
 

--- a/Tests/ObservationTests.swift
+++ b/Tests/ObservationTests.swift
@@ -11,11 +11,14 @@
 //  Copyright © 2021-present Jesse Squires
 //
 
+#if canImport(Combine)
 import Combine
+#endif
+
 @testable import Foil
 import XCTest
 
-@available(iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+@available(iOS 13.0, watchOS 6.0, tvOS 13.0, macOS 10.15, *)
 final class ObservationTests: XCTestCase {
 
     let settings = TestSettings()


### PR DESCRIPTION
- Lower iOS and tvOS to 9.0, closes #16
- Correct SPM platforms and make consistent with podspec, closes #18

This also separates tests into `ObservationTests`, which we can mark as `@available` so that building/running via SPM works.
