### PR TITLE
Implement succinct implicit initialization

### DIFF
--- a/Example/ExampleApp/AppSettings.swift
+++ b/Example/ExampleApp/AppSettings.swift
@@ -16,16 +16,16 @@ enum AppSettingsKey: String, CaseIterable {
 final class AppSettings {
     static let shared = AppSettings()
 
-    @WrappedDefault(key: .flagEnabled, defaultValue: true)
-    var flagEnabled: Bool
+    @WrappedDefault(.flagEnabled)
+    var flagEnabled = true
 
-    @WrappedDefault(key: .totalCount, defaultValue: 0)
-    var totalCount: Int
+    @WrappedDefault(.totalCount)
+    var totalCount = 0
 
-    @WrappedDefaultOptional(key: .timestamp)
+    @WrappedDefaultOptional(.timestamp)
     var timestamp: Date?
 
-    @WrappedDefaultOptional(key: .option)
+    @WrappedDefaultOptional(.option)
     var option: String?
 
     private init() { }
@@ -37,13 +37,13 @@ final class AppSettings {
 }
 
 extension WrappedDefault {
-    init(key: AppSettingsKey, defaultValue: T) {
-        self.init(keyName: key.rawValue, defaultValue: defaultValue)
+    init(wrappedValue: T, _ key: AppSettingsKey) {
+        self.init(wrappedValue: wrappedValue, key: key.rawValue)
     }
 }
 
 extension WrappedDefaultOptional {
-    init(key: AppSettingsKey) {
-        self.init(keyName: key.rawValue)
+    init(_ key: AppSettingsKey) {
+        self.init(key: key.rawValue)
     }
 }

--- a/Sources/WrappedDefault.swift
+++ b/Sources/WrappedDefault.swift
@@ -22,7 +22,7 @@ public struct WrappedDefault<T: UserDefaultsSerializable> {
     /// The key for the value in `UserDefaults`.
     public let key: String
 
-    /// The value retreived from `UserDefaults`.
+    /// The value retrieved from `UserDefaults`.
     public var wrappedValue: T {
         get {
             self._userDefaults.fetch(self.key)
@@ -34,14 +34,12 @@ public struct WrappedDefault<T: UserDefaultsSerializable> {
 
     /// Initializes the property wrapper.
     /// - Parameters:
+    ///   - wrappedValue: The default value to register for the specified key.
     ///   - keyName: The key for the value in `UserDefaults`.
-    ///   - defaultValue: The default value to register for the specified key.
     ///   - userDefaults: The `UserDefaults` backing store. The default value is `.standard`.
-    public init(keyName: String,
-                defaultValue: T,
-                userDefaults: UserDefaults = .standard) {
+    public init(wrappedValue: T, key keyName: String, userDefaults: UserDefaults = .standard) {
         self.key = keyName
         self._userDefaults = userDefaults
-        userDefaults.registerDefault(value: defaultValue, key: keyName)
+        userDefaults.registerDefault(value: wrappedValue, key: keyName)
     }
 }

--- a/Sources/WrappedDefaultOptional.swift
+++ b/Sources/WrappedDefaultOptional.swift
@@ -40,8 +40,7 @@ public struct WrappedDefaultOptional<T: UserDefaultsSerializable> {
     /// - Parameters:
     ///   - keyName: The key for the value in `UserDefaults`.
     ///   - userDefaults: The `UserDefaults` backing store. The default value is `.standard`.
-    public init(keyName: String,
-                userDefaults: UserDefaults = .standard) {
+    public init(key keyName: String, userDefaults: UserDefaults = .standard) {
         self.key = keyName
         self._userDefaults = userDefaults
     }

--- a/Tests/TestSettings.swift
+++ b/Tests/TestSettings.swift
@@ -41,48 +41,48 @@ final class TestSettings: NSObject {
 
     static var store = UserDefaults.testSuite()
 
-    @WrappedDefault(keyName: "flag", defaultValue: true, userDefaults: store)
-    var flag: Bool
+    @WrappedDefault(key: "flag", userDefaults: store)
+    var flag = true
 
-    @WrappedDefault(keyName: "count", defaultValue: 42, userDefaults: store)
-    var count: Int
+    @WrappedDefault(key: "count", userDefaults: store)
+    var count = 42
 
-    @WrappedDefault(keyName: "max", defaultValue: 42, userDefaults: store)
-    var max: UInt
+    @WrappedDefault(key: "max", userDefaults: store)
+    var max = UInt(42)
 
-    @WrappedDefault(keyName: "mean", defaultValue: 4.2, userDefaults: store)
-    var mean: Float
+    @WrappedDefault(key: "mean", userDefaults: store)
+    var mean = Float(4.2)
 
-    @WrappedDefault(keyName: "average", defaultValue: 42.0, userDefaults: store)
-    var average: Double
+    @WrappedDefault(key: "average", userDefaults: store)
+    var average = 42.0
 
-    @WrappedDefaultOptional(keyName: "username", userDefaults: store)
+    @WrappedDefaultOptional(key: "username", userDefaults: store)
     var username: String?
 
-    @WrappedDefaultOptional(keyName: "website", userDefaults: store)
+    @WrappedDefaultOptional(key: "website", userDefaults: store)
     var website: URL?
 
-    @WrappedDefault(keyName: "timestamp", defaultValue: .distantPast, userDefaults: store)
-    var timestamp: Date
+    @WrappedDefault(key: "timestamp", userDefaults: store)
+    var timestamp = Date.distantPast
 
-    @WrappedDefaultOptional(keyName: "data", userDefaults: store)
+    @WrappedDefaultOptional(key: "data", userDefaults: store)
     var data: Data?
 
-    @WrappedDefault(keyName: "list", defaultValue: [], userDefaults: store)
-    var list: [Double]
+    @WrappedDefault(key: "list", userDefaults: store)
+    var list = [Double]()
 
-    @WrappedDefault(keyName: "set", defaultValue: [1, 2, 3], userDefaults: store)
-    var set: Set<Int>
+    @WrappedDefault(key: "set", userDefaults: store)
+    var set = Set([1, 2, 3])
 
-    @WrappedDefault(keyName: "pairs", defaultValue: [:], userDefaults: store)
-    var pairs: [String: Int]
+    @WrappedDefault(key: "pairs", userDefaults: store)
+    var pairs = [String: Int]()
 
-    @WrappedDefault(keyName: "fruit", defaultValue: .apple, userDefaults: store)
-    var fruit: TestFruit
+    @WrappedDefault(key: "fruit", userDefaults: store)
+    var fruit = TestFruit.apple
 
-    @WrappedDefault(keyName: "customRawRepresented", defaultValue: TestCustomRepresented(rawValue: [:]), userDefaults: store)
-    var customRawRepresented: TestCustomRepresented
+    @WrappedDefault(key: "customRawRepresented", userDefaults: store)
+    var customRawRepresented = TestCustomRepresented(rawValue: [:])
 
-    @WrappedDefaultOptional(keyName: "userId", userDefaults: store)
+    @WrappedDefaultOptional(key: "userId", userDefaults: store)
     @objc dynamic var userId: String?
 }

--- a/Tests/WrappedDefaultTests.swift
+++ b/Tests/WrappedDefaultTests.swift
@@ -31,7 +31,7 @@ final class WrappedDefaultTests: XCTestCase {
     func test_WrappedValue_Bool() {
         let key = "key_\(#function)"
         let defaultValue = true
-        var model = WrappedDefault(keyName: key, defaultValue: defaultValue, userDefaults: self.testDefaults)
+        var model = WrappedDefault(wrappedValue: defaultValue, key: key, userDefaults: self.testDefaults)
 
         XCTAssertEqual(self.testDefaults.fetch(key), defaultValue)
         XCTAssertEqual(model.wrappedValue, defaultValue)
@@ -45,7 +45,7 @@ final class WrappedDefaultTests: XCTestCase {
     func test_WrappedValue_Int() {
         let key = "key_\(#function)"
         let defaultValue = 42
-        var model = WrappedDefault(keyName: key, defaultValue: defaultValue, userDefaults: self.testDefaults)
+        var model = WrappedDefault(wrappedValue: defaultValue, key: key, userDefaults: self.testDefaults)
 
         XCTAssertEqual(self.testDefaults.fetch(key), defaultValue)
         XCTAssertEqual(model.wrappedValue, defaultValue)
@@ -59,7 +59,7 @@ final class WrappedDefaultTests: XCTestCase {
     func test_WrappedValue_UInt() {
         let key = "key_\(#function)"
         let defaultValue = UInt(42)
-        var model = WrappedDefault(keyName: key, defaultValue: defaultValue, userDefaults: self.testDefaults)
+        var model = WrappedDefault(wrappedValue: defaultValue, key: key, userDefaults: self.testDefaults)
 
         XCTAssertEqual(self.testDefaults.fetch(key), defaultValue)
         XCTAssertEqual(model.wrappedValue, defaultValue)
@@ -73,7 +73,7 @@ final class WrappedDefaultTests: XCTestCase {
     func test_WrappedValue_Float() {
         let key = "key_\(#function)"
         let defaultValue = Float(42.0)
-        var model = WrappedDefault(keyName: key, defaultValue: defaultValue, userDefaults: self.testDefaults)
+        var model = WrappedDefault(wrappedValue: defaultValue, key: key, userDefaults: self.testDefaults)
 
         XCTAssertEqual(self.testDefaults.fetch(key), defaultValue)
         XCTAssertEqual(model.wrappedValue, defaultValue)
@@ -87,7 +87,7 @@ final class WrappedDefaultTests: XCTestCase {
     func test_WrappedValue_Double() {
         let key = "key_\(#function)"
         let defaultValue = Double(42.0)
-        var model = WrappedDefault(keyName: key, defaultValue: defaultValue, userDefaults: self.testDefaults)
+        var model = WrappedDefault(wrappedValue: defaultValue, key: key, userDefaults: self.testDefaults)
 
         XCTAssertEqual(self.testDefaults.fetch(key), defaultValue)
         XCTAssertEqual(model.wrappedValue, defaultValue)
@@ -101,7 +101,7 @@ final class WrappedDefaultTests: XCTestCase {
     func test_WrappedValue_String() {
         let key = "key_\(#function)"
         let defaultValue = "default-value"
-        var model = WrappedDefault(keyName: key, defaultValue: defaultValue, userDefaults: self.testDefaults)
+        var model = WrappedDefault(wrappedValue: defaultValue, key: key, userDefaults: self.testDefaults)
 
         XCTAssertEqual(self.testDefaults.fetch(key), defaultValue)
         XCTAssertEqual(model.wrappedValue, defaultValue)
@@ -115,7 +115,7 @@ final class WrappedDefaultTests: XCTestCase {
     func test_WrappedValue_URL() {
         let key = "key_\(#function)"
         let defaultValue = URL(string: "https://hexedbits.com")!
-        var model = WrappedDefault(keyName: key, defaultValue: defaultValue, userDefaults: self.testDefaults)
+        var model = WrappedDefault(wrappedValue: defaultValue, key: key, userDefaults: self.testDefaults)
 
         XCTAssertEqual(self.testDefaults.fetch(key), defaultValue)
         XCTAssertEqual(model.wrappedValue, defaultValue)
@@ -129,7 +129,7 @@ final class WrappedDefaultTests: XCTestCase {
     func test_WrappedValue_Date() {
         let key = "key_\(#function)"
         let defaultValue = Date.distantPast
-        var model = WrappedDefault(keyName: key, defaultValue: defaultValue, userDefaults: self.testDefaults)
+        var model = WrappedDefault(wrappedValue: defaultValue, key: key, userDefaults: self.testDefaults)
 
         XCTAssertEqual(self.testDefaults.fetch(key), defaultValue)
         XCTAssertEqual(model.wrappedValue, defaultValue)
@@ -143,7 +143,7 @@ final class WrappedDefaultTests: XCTestCase {
     func test_WrappedValue_Data() {
         let key = "key_\(#function)"
         let defaultValue = "default-data".data(using: .utf8)!
-        var model = WrappedDefault(keyName: key, defaultValue: defaultValue, userDefaults: self.testDefaults)
+        var model = WrappedDefault(wrappedValue: defaultValue, key: key, userDefaults: self.testDefaults)
 
         XCTAssertEqual(self.testDefaults.fetch(key), defaultValue)
         XCTAssertEqual(model.wrappedValue, defaultValue)
@@ -157,7 +157,7 @@ final class WrappedDefaultTests: XCTestCase {
     func test_WrappedValue_Array() {
         let key = "key_\(#function)"
         let defaultValue = [1, 2, 3]
-        var model = WrappedDefault(keyName: key, defaultValue: defaultValue, userDefaults: self.testDefaults)
+        var model = WrappedDefault(wrappedValue: defaultValue, key: key, userDefaults: self.testDefaults)
 
         XCTAssertEqual(self.testDefaults.fetch(key), defaultValue)
         XCTAssertEqual(model.wrappedValue, defaultValue)
@@ -171,7 +171,7 @@ final class WrappedDefaultTests: XCTestCase {
     func test_WrappedValue_Set() {
         let key = "key_\(#function)"
         let defaultValue = Set(["one", "two", "three"])
-        var model = WrappedDefault(keyName: key, defaultValue: defaultValue, userDefaults: self.testDefaults)
+        var model = WrappedDefault(wrappedValue: defaultValue, key: key, userDefaults: self.testDefaults)
 
         XCTAssertEqual(self.testDefaults.fetch(key), defaultValue)
         XCTAssertEqual(model.wrappedValue, defaultValue)
@@ -186,7 +186,7 @@ final class WrappedDefaultTests: XCTestCase {
         let key = "key_\(#function)"
         let defaultValue = ["key1": 42.0,
                             "key2": 4.2]
-        var model = WrappedDefault(keyName: key, defaultValue: defaultValue, userDefaults: self.testDefaults)
+        var model = WrappedDefault(wrappedValue: defaultValue, key: key, userDefaults: self.testDefaults)
 
         XCTAssertEqual(self.testDefaults.fetch(key), defaultValue)
         XCTAssertEqual(model.wrappedValue, defaultValue)
@@ -200,7 +200,7 @@ final class WrappedDefaultTests: XCTestCase {
     func test_WrappedValue_RawRepresentable() {
         let key = "key_\(#function)"
         let defaultValue = TestFruit.apple
-        var model = WrappedDefault(keyName: key, defaultValue: defaultValue, userDefaults: self.testDefaults)
+        var model = WrappedDefault(wrappedValue: defaultValue, key: key, userDefaults: self.testDefaults)
 
         XCTAssertEqual(self.testDefaults.fetch(key), defaultValue)
         XCTAssertEqual(model.wrappedValue, defaultValue)
@@ -213,7 +213,7 @@ final class WrappedDefaultTests: XCTestCase {
 
     func test_WrappedValue_IntOptional() {
         let key = "key_\(#function)"
-        var model = WrappedDefaultOptional<Int>(keyName: key, userDefaults: self.testDefaults)
+        var model = WrappedDefaultOptional<Int>(key: key, userDefaults: self.testDefaults)
 
         let defaultValue: Int? = self.testDefaults.fetchOptional(key)
         XCTAssertNil(defaultValue)
@@ -233,7 +233,7 @@ final class WrappedDefaultTests: XCTestCase {
 
     func test_WrappedValue_StringOptional() {
         let key = "key_\(#function)"
-        var model = WrappedDefaultOptional<String>(keyName: key, userDefaults: self.testDefaults)
+        var model = WrappedDefaultOptional<String>(key: key, userDefaults: self.testDefaults)
 
         let defaultValue: String? = self.testDefaults.fetchOptional(key)
         XCTAssertNil(defaultValue)
@@ -253,7 +253,7 @@ final class WrappedDefaultTests: XCTestCase {
 
     func test_WrappedValue_URLOptional() {
         let key = "key_\(#function)"
-        var model = WrappedDefaultOptional<URL>(keyName: key, userDefaults: self.testDefaults)
+        var model = WrappedDefaultOptional<URL>(key: key, userDefaults: self.testDefaults)
 
         let defaultValue: URL? = self.testDefaults.fetchOptional(key)
         XCTAssertNil(defaultValue)
@@ -273,7 +273,7 @@ final class WrappedDefaultTests: XCTestCase {
 
     func test_WrappedValue_DateOptional() {
         let key = "key_\(#function)"
-        var model = WrappedDefaultOptional<Date>(keyName: key, userDefaults: self.testDefaults)
+        var model = WrappedDefaultOptional<Date>(key: key, userDefaults: self.testDefaults)
 
         let defaultValue: Date? = self.testDefaults.fetchOptional(key)
         XCTAssertNil(defaultValue)
@@ -294,7 +294,7 @@ final class WrappedDefaultTests: XCTestCase {
     // swiftlint:disable discouraged_optional_collection
     func test_WrappedValue_DictionaryOptional() {
         let key = "key_\(#function)"
-        var model = WrappedDefaultOptional<[String: TestFruit]>(keyName: key, userDefaults: self.testDefaults)
+        var model = WrappedDefaultOptional<[String: TestFruit]>(key: key, userDefaults: self.testDefaults)
 
         let defaultValue: [String: TestFruit]? = self.testDefaults.fetchOptional(key)
         XCTAssertNil(defaultValue)


### PR DESCRIPTION
This implements the  succinct implicit initialization described in #29.

This is much nicer.

Closes #29.
