### PR TITLE
Add SwiftUI example

### DIFF
--- a/Example/ExampleApp.xcodeproj/project.pbxproj
+++ b/Example/ExampleApp.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		0BEEA306260421290035387F /* Foil.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0BEEA2FE26041FED0035387F /* Foil.framework */; };
 		0BEEA307260421290035387F /* Foil.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 0BEEA2FE26041FED0035387F /* Foil.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		0BEEA30A260421BE0035387F /* AppSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BEEA309260421BE0035387F /* AppSettings.swift */; };
+		8BC9315B27D87B9E0077E21F /* SwiftUIExampleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BC9315A27D87B9E0077E21F /* SwiftUIExampleView.swift */; };
 		DD7A60F927777AD2009FBF27 /* CombineExampleViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD7A60F827777AD2009FBF27 /* CombineExampleViewController.swift */; };
 /* End PBXBuildFile section */
 
@@ -61,6 +62,7 @@
 		0BEEA2EF26041EB20035387F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		0BEEA2F826041FED0035387F /* Foil.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = Foil.xcodeproj; path = ../Foil.xcodeproj; sourceTree = "<group>"; };
 		0BEEA309260421BE0035387F /* AppSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSettings.swift; sourceTree = "<group>"; };
+		8BC9315A27D87B9E0077E21F /* SwiftUIExampleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftUIExampleView.swift; sourceTree = "<group>"; };
 		DD7A60F827777AD2009FBF27 /* CombineExampleViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CombineExampleViewController.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -101,6 +103,7 @@
 				0BEEA309260421BE0035387F /* AppSettings.swift */,
 				0BEEA2EA26041EB20035387F /* Assets.xcassets */,
 				DD7A60F827777AD2009FBF27 /* CombineExampleViewController.swift */,
+				8BC9315A27D87B9E0077E21F /* SwiftUIExampleView.swift */,
 				0BEEA2EF26041EB20035387F /* Info.plist */,
 				0BEEA2EC26041EB20035387F /* LaunchScreen.storyboard */,
 				0BEEA2E726041EB00035387F /* Main.storyboard */,
@@ -222,6 +225,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				0BEEA2E626041EB00035387F /* ViewController.swift in Sources */,
+				8BC9315B27D87B9E0077E21F /* SwiftUIExampleView.swift in Sources */,
 				DD7A60F927777AD2009FBF27 /* CombineExampleViewController.swift in Sources */,
 				0BEEA2E226041EB00035387F /* AppDelegate.swift in Sources */,
 				0BEEA30A260421BE0035387F /* AppSettings.swift in Sources */,

--- a/Example/ExampleApp/Base.lproj/Main.storyboard
+++ b/Example/ExampleApp/Base.lproj/Main.storyboard
@@ -91,13 +91,13 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="eQB-65-Cc7" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1373.913043478261" y="853.79464285714278"/>
+            <point key="canvasLocation" x="2407" y="854"/>
         </scene>
         <!--SwiftUI Example-->
         <scene sceneID="aYl-9w-e1l">
             <objects>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="6wg-hq-V21" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
-                <navigationController id="qeM-ea-Ji2" sceneMemberID="viewController">
+                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="qeM-ea-Ji2" sceneMemberID="viewController">
                     <tabBarItem key="tabBarItem" title="SwiftUI Example" image="sparkles" catalog="system" id="51J-9b-V70"/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="PDi-2h-UFd">
                         <rect key="frame" x="0.0" y="44" width="414" height="44"/>
@@ -163,7 +163,7 @@
                 </navigationController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Wj7-8r-Pew" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="463.768115942029" y="853.79464285714278"/>
+            <point key="canvasLocation" x="1374" y="854"/>
         </scene>
     </scenes>
     <resources>

--- a/Example/ExampleApp/Base.lproj/Main.storyboard
+++ b/Example/ExampleApp/Base.lproj/Main.storyboard
@@ -93,6 +93,39 @@
             </objects>
             <point key="canvasLocation" x="1373.913043478261" y="853.79464285714278"/>
         </scene>
+        <!--SwiftUI Example-->
+        <scene sceneID="aYl-9w-e1l">
+            <objects>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="6wg-hq-V21" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+                <navigationController id="qeM-ea-Ji2" sceneMemberID="viewController">
+                    <tabBarItem key="tabBarItem" title="SwiftUI Example" image="sparkles" catalog="system" id="51J-9b-V70"/>
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="PDi-2h-UFd">
+                        <rect key="frame" x="0.0" y="44" width="414" height="44"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </navigationBar>
+                    <connections>
+                        <segue destination="OgM-4o-cBL" kind="relationship" relationship="rootViewController" id="VIL-ja-D7w"/>
+                    </connections>
+                </navigationController>
+            </objects>
+            <point key="canvasLocation" x="1374" y="-660"/>
+        </scene>
+        <!--SwiftUI Example Host View Controller-->
+        <scene sceneID="ucB-nk-qWe">
+            <objects>
+                <viewController id="OgM-4o-cBL" customClass="SwiftUIExampleHostViewController" customModule="ExampleApp" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="aNI-2s-dlg">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <viewLayoutGuide key="safeArea" id="mMZ-Ch-Lub"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    </view>
+                    <navigationItem key="navigationItem" id="hgT-XT-2Q9"/>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Sxs-Cw-MZC" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="2407" y="-660"/>
+        </scene>
         <!--Tab Bar Controller-->
         <scene sceneID="F0C-CX-4hV">
             <objects>
@@ -106,6 +139,7 @@
                     <connections>
                         <segue destination="XxT-hh-v2S" kind="relationship" relationship="viewControllers" id="V7R-yB-xe6"/>
                         <segue destination="5zf-9Z-6TF" kind="relationship" relationship="viewControllers" id="cDY-4H-cB7"/>
+                        <segue destination="qeM-ea-Ji2" kind="relationship" relationship="viewControllers" id="Hgw-tR-g5M"/>
                     </connections>
                 </tabBarController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Lk8-Pv-mYy" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
@@ -135,6 +169,7 @@
     <resources>
         <image name="arrow.triangle.2.circlepath" catalog="system" width="128" height="101"/>
         <image name="gear" catalog="system" width="128" height="119"/>
+        <image name="sparkles" catalog="system" width="112" height="128"/>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>

--- a/Example/ExampleApp/SwiftUIExampleView.swift
+++ b/Example/ExampleApp/SwiftUIExampleView.swift
@@ -40,8 +40,8 @@ struct SwiftUIExampleView: View {
     }
 }
 
-final class SwiftUIExampleHostViewController: UIHostingController<SwiftUIExampleView>{
-    required init?(coder aDecoder: NSCoder){
+final class SwiftUIExampleHostViewController: UIHostingController<SwiftUIExampleView> {
+    required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder, rootView: SwiftUIExampleView())
     }
 }

--- a/Example/ExampleApp/SwiftUIExampleView.swift
+++ b/Example/ExampleApp/SwiftUIExampleView.swift
@@ -1,0 +1,47 @@
+//
+//  Created by Jesse Squires
+//  https://www.jessesquires.com
+//
+//  Documentation
+//  https://jessesquires.github.io/Foil
+//
+//  GitHub
+//  https://github.com/jessesquires/Foil
+//
+//  Copyright © 2021-present Jesse Squires
+//
+
+import SwiftUI
+
+struct SwiftUIExampleView: View {
+    @State private var flagEnabled = false
+
+    var body: some View {
+        VStack {
+            Toggle(isOn: $flagEnabled) {
+                Text(flagEnabled.description)
+            }
+            GroupBox {
+                Button("Simulate outside trigger") {
+                    AppSettings.shared.flagEnabled.toggle()
+                }
+            }
+        }
+        .padding()
+        .navigationTitle("SwiftUI Example")
+        .onChange(of: flagEnabled) {
+            // User interaction stores into settings
+            AppSettings.shared.flagEnabled = $0
+        }
+        .onReceive(AppSettings.shared.$flagEnabled) {
+            // Listen to settings change
+            flagEnabled = $0
+        }
+    }
+}
+
+final class SwiftUIExampleHostViewController: UIHostingController<SwiftUIExampleView>{
+    required init?(coder aDecoder: NSCoder){
+        super.init(coder: aDecoder, rootView: SwiftUIExampleView())
+    }
+}


### PR DESCRIPTION
Issue #45 

## Describe your changes

Provides a SwiftUI example to show usage of Foil. This is particularly needed since multiple property wrappers is not available in Swift yet so this shows how a SwiftUI view can listen for changes.

![Simulator Screen Recording - iPhone 13 - 2022-03-09 at 01 29 43](https://user-images.githubusercontent.com/892152/157385379-4a06881b-35cb-4cc3-afc7-13fc5eabeb10.gif)

