### PR TITLE
Improve SwiftUI example

### DIFF
--- a/Example/ExampleApp/AppSettings.swift
+++ b/Example/ExampleApp/AppSettings.swift
@@ -21,11 +21,15 @@ enum AppSettingsKey: String, CaseIterable {
     case option
 }
 
-final class AppSettings: NSObject {
+final class AppSettings: NSObject, ObservableObject {
     static let shared = AppSettings()
 
     @WrappedDefault(.flagEnabled)
-    @objc dynamic var flagEnabled = true
+    @objc dynamic var flagEnabled = true {
+        willSet {
+            objectWillChange.send()
+        }
+    }
 
     @WrappedDefault(.totalCount)
     var totalCount = 0

--- a/Example/ExampleApp/AppSettings.swift
+++ b/Example/ExampleApp/AppSettings.swift
@@ -32,13 +32,25 @@ final class AppSettings: NSObject, ObservableObject {
     }
 
     @WrappedDefault(.totalCount)
-    var totalCount = 0
+    var totalCount = 0 {
+        willSet {
+            objectWillChange.send()
+        }
+    }
 
     @WrappedDefaultOptional(.timestamp)
-    var timestamp: Date?
+    var timestamp: Date? {
+        willSet {
+            objectWillChange.send()
+        }
+    }
 
     @WrappedDefaultOptional(.option)
-    var option: String?
+    var option: String? {
+        willSet {
+            objectWillChange.send()
+        }
+    }
 
     override private init() { }
 

--- a/Example/ExampleApp/SwiftUIExampleView.swift
+++ b/Example/ExampleApp/SwiftUIExampleView.swift
@@ -14,29 +14,17 @@
 import SwiftUI
 
 struct SwiftUIExampleView: View {
-    @State private var flagEnabled = false
+
+    @ObservedObject private var settings: AppSettings = .shared
 
     var body: some View {
         VStack {
-            Toggle(isOn: $flagEnabled) {
-                Text(flagEnabled.description)
-            }
-            GroupBox {
-                Button("Simulate outside trigger") {
-                    AppSettings.shared.flagEnabled.toggle()
-                }
+            Toggle(isOn: $settings.flagEnabled) {
+                Text(settings.flagEnabled.description)
             }
         }
         .padding()
         .navigationTitle("SwiftUI Example")
-        .onChange(of: flagEnabled) {
-            // User interaction stores into settings
-            AppSettings.shared.flagEnabled = $0
-        }
-        .onReceive(AppSettings.shared.$flagEnabled) {
-            // Listen to settings change
-            flagEnabled = $0
-        }
     }
 }
 


### PR DESCRIPTION
## Describe your changes
Simplifies SwiftUI example as discussed here #57 

- adds `ObservableObject` conformance to `AppSettings` and showcases integration in SwiftUI
- removes need for `.onChange` / `onReceive` modifiers
- removes now unnecessary outside trigger
