### PR TITLE
Send on projectedValue publisher for any change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,23 @@ The changelog for `Foil`. Also see the [releases](https://github.com/jessesquire
 NEXT
 -----
 
+- TBA
+
+4.0.0
+-----
+
 ### New
 
-- The publisher projected by the property wrapper now sends values when user defaults changes from anywhere, not just from the property wrapper's setter. ([@nolanw](https://github.com/nolanw))
+- The publisher projected by the property wrapper now sends values when user defaults changes from anywhere. Previously, only when using the property wrapper's setter would the projected publisher send a new value. ([#61](https://github.com/jessesquires/Foil/pull/61), [@nolanw](https://github.com/nolanw))
+
+### Breaking
+
+- Due to [#61](https://github.com/jessesquires/Foil/pull/61) (see above), there are some (potentially) breaking changes with key names. If any of your keys are named like the following examples and you need to observe changes, you will need to migrate your key names.
+    - Key names starting with an `@` character **do not** notify observers on updates.
+        - Example: `@my-key-name`
+    - Key names containing a `.` character _anywhere_ in the name **do not** notify observers on updates. (This is a side-effect of `KeyPaths` which include periods.)
+        - Example: `com.myApp.my-key-name`
+
 
 3.0.0
 -----

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ The changelog for `Foil`. Also see the [releases](https://github.com/jessesquire
 NEXT
 -----
 
-- TBA
+### New
+
+- The publisher projected by the property wrapper now sends values when user defaults changes from anywhere, not just from the property wrapper's setter. ([@nolanw](https://github.com/nolanw))
 
 3.0.0
 -----

--- a/Foil.xcodeproj/project.pbxproj
+++ b/Foil.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		0BF54A9D25BF58B1008484F8 /* UserDefaults+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BF54A9C25BF58B1008484F8 /* UserDefaults+Extensions.swift */; };
 		0BF5FD9025C14A7D0003B078 /* WrappedDefault.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BF5FD8F25C14A7D0003B078 /* WrappedDefault.swift */; };
 		0BF5FD9625C14A960003B078 /* UserDefaultsSerializable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BF5FD9525C14A960003B078 /* UserDefaultsSerializable.swift */; };
+		1CC00F2428DAB1FC00EC2C63 /* ObserverTrampoline.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CC00F2328DAB1FC00EC2C63 /* ObserverTrampoline.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -41,6 +42,7 @@
 		0BF54A9C25BF58B1008484F8 /* UserDefaults+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserDefaults+Extensions.swift"; sourceTree = "<group>"; };
 		0BF5FD8F25C14A7D0003B078 /* WrappedDefault.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WrappedDefault.swift; sourceTree = "<group>"; };
 		0BF5FD9525C14A960003B078 /* UserDefaultsSerializable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultsSerializable.swift; sourceTree = "<group>"; };
+		1CC00F2328DAB1FC00EC2C63 /* ObserverTrampoline.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ObserverTrampoline.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -83,6 +85,7 @@
 		0BF54A8225BF589E008484F8 /* Sources */ = {
 			isa = PBXGroup;
 			children = (
+				1CC00F2328DAB1FC00EC2C63 /* ObserverTrampoline.swift */,
 				0BF54A9C25BF58B1008484F8 /* UserDefaults+Extensions.swift */,
 				0BF5FD9525C14A960003B078 /* UserDefaultsSerializable.swift */,
 				0BF5FD8F25C14A7D0003B078 /* WrappedDefault.swift */,
@@ -235,6 +238,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				0BF5FD9625C14A960003B078 /* UserDefaultsSerializable.swift in Sources */,
+				1CC00F2428DAB1FC00EC2C63 /* ObserverTrampoline.swift in Sources */,
 				0BEEA2B22603F8390035387F /* WrappedDefaultOptional.swift in Sources */,
 				0BF5FD9025C14A7D0003B078 /* WrappedDefault.swift in Sources */,
 				0BF54A9D25BF58B1008484F8 /* UserDefaults+Extensions.swift in Sources */,

--- a/Sources/ObserverTrampoline.swift
+++ b/Sources/ObserverTrampoline.swift
@@ -24,6 +24,8 @@ final class ObserverTrampoline: NSObject {
     private let block: () -> Void
 
     init(userDefaults: UserDefaults, key: String, block: @escaping () -> Void) {
+        assert(!key.hasPrefix("@"), "Cannot observe a user default key starting with '@'")
+        assert(!key.contains("."), "Cannot observe a user default key containing '.'")
         self.userDefaults = userDefaults
         self.key = key
         self.block = block

--- a/Sources/ObserverTrampoline.swift
+++ b/Sources/ObserverTrampoline.swift
@@ -1,0 +1,42 @@
+//
+//  Created by Jesse Squires
+//  https://www.jessesquires.com
+//
+//  Documentation
+//  https://jessesquires.github.io/Foil
+//
+//  GitHub
+//  https://github.com/jessesquires/Foil
+//
+//  Copyright © 2021-present Jesse Squires
+//
+
+import Foundation
+
+/// Watches for changes to UserDefaults using old-school Key-Value Observing.
+///
+/// KVO allows us to be notified of changes from anywhere (including other processes), not just via the property wrapper's setter.
+///
+/// We can't use Swift's block-based KVO because that requires a KeyPath, which we cannot create from a String.
+final class ObserverTrampoline: NSObject {
+    private let userDefaults: UserDefaults
+    private let key: String
+    private let block: () -> Void
+
+    init(userDefaults: UserDefaults, key: String, block: @escaping () -> Void) {
+        self.userDefaults = userDefaults
+        self.key = key
+        self.block = block
+        super.init()
+
+        userDefaults.addObserver(self, forKeyPath: key, context: nil)
+    }
+
+    override func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey: Any]?, context: UnsafeMutableRawPointer?) {
+        block()
+    }
+
+    deinit {
+        userDefaults.removeObserver(self, forKeyPath: key, context: nil)
+    }
+}

--- a/Tests/ObservationTests.swift
+++ b/Tests/ObservationTests.swift
@@ -11,6 +11,7 @@
 //  Copyright © 2021-present Jesse Squires
 //
 
+@testable import Foil
 import Combine
 import XCTest
 

--- a/Tests/ObservationTests.swift
+++ b/Tests/ObservationTests.swift
@@ -53,6 +53,27 @@ final class ObservationTests: XCTestCase {
         XCTAssertEqual(self.settings.average, publishedValue)
     }
 
+    func test_Integration_ProjectedValue_ExternalChange() {
+        let expectation = self.expectation(description: #function)
+        let expectedValue = 1_000.0
+        var publishedValue: Double?
+
+        self.settings.$average
+            .sink { newValue in
+                publishedValue = newValue
+
+                if newValue == expectedValue {
+                    expectation.fulfill()
+                }
+            }
+            .store(in: &self.cancellable)
+
+        type(of: self.settings).store.set(expectedValue, forKey: "average")
+        self.wait(for: [expectation], timeout: timeout)
+
+        XCTAssertEqual(self.settings.average, publishedValue)
+    }
+
     func test_Integration_Publisher() {
         let expectation = self.expectation(description: #function)
         var publishedValue: String?


### PR DESCRIPTION
Hello! Previously, only when using the property wrapper's setter would the projected publisher send a new value. This ignored changes from:

- Other instances of the property wrapper.
- Other libraries that persist to UserDefaults.
- Direct callers of UserDefaults.
- Other processes.

Now the projected publisher sends the new value no matter where the change occurs.

(I brought this up in #38 and figured I'd continue discussion in a PR, instead of an issue. I hope that's alright :)