### PR TITLE
Prevent crash when types are mismatched

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ The changelog for `Foil`. Also see the [releases](https://github.com/jessesquire
 NEXT
 -----
 
-- TBA
+### Changed
+
+- `WrappedDefaultOptional` no longer crashes when the type stored in the defaults does not match the type being requested. `nil` is now returned instead.
 
 4.0.0
 -----

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,14 @@ The changelog for `Foil`. Also see the [releases](https://github.com/jessesquire
 NEXT
 -----
 
-### Changed
+- TBA
 
-- `WrappedDefaultOptional` no longer crashes when the type stored in the defaults does not match the type being requested. `nil` is now returned instead.
+4.0.1
+-----
+
+### Fixed
+
+- `WrappedDefaultOptional` no longer crashes when the type stored in `UserDefaults` does not match the type being requested, `nil` is now returned instead. ([#70](https://github.com/jessesquires/Foil/pull/70), [@ejensen](https://github.com/ejensen))
 
 4.0.0
 -----

--- a/Sources/UserDefaults+Extensions.swift
+++ b/Sources/UserDefaults+Extensions.swift
@@ -52,7 +52,11 @@ extension UserDefaults {
             return nil
         }
 
-        return T(storedValue: fetched as! T.StoredValue)
+        guard let storedValue = fetched as? T.StoredValue else {
+            return nil
+        }
+
+        return T(storedValue: storedValue)
     }
 
     func registerDefault<T: UserDefaultsSerializable>(value: T, key: String) {

--- a/Tests/WrappedDefaultTests.swift
+++ b/Tests/WrappedDefaultTests.swift
@@ -312,4 +312,15 @@ final class WrappedDefaultTests: XCTestCase {
         XCTAssertNil(fetchedValue)
     }
     // swiftlint:enable discouraged_optional_collection
+
+    func test_WrappedValue_MismatchedOptional() {
+        let key = "key_\(#function)"
+        let model = WrappedDefaultOptional<Date>(key: key, userDefaults: self.testDefaults)
+        testDefaults.save("not-a-date", for: key)
+
+        let defaultValue: Date? = self.testDefaults.fetchOptional(key)
+        XCTAssertNil(defaultValue)
+        XCTAssertNil(model.wrappedValue)
+    }
+
 }

--- a/Tests/WrappedDefaultTests.swift
+++ b/Tests/WrappedDefaultTests.swift
@@ -322,5 +322,4 @@ final class WrappedDefaultTests: XCTestCase {
         XCTAssertNil(defaultValue)
         XCTAssertNil(model.wrappedValue)
     }
-
 }


### PR DESCRIPTION
## Describe your changes

This change prevents a force-casting crash when fetching a wrapped value with mismatched types. `nil` is returned instead. A mismatched type can be caused by a redefinition of a key or data corruption. The change allows Foil intergrators to handle the `nil` case rather than crashing. This change does not impact the public interface and adds a unit test to verify mismatched types are handled.