### PR TITLE
Fix crash dereferencing unowned _publisher in KVO trampoline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ NEXT
 5.1.2
 -----
 
-- Fix crash when receiving a KVO notification and so attempting to send a value to `FoilDefaultStorage` or `FoilDefaultStorageOptional`'s publisher after the storage is deallocated.
+- Fixed possible crash when receiving a KVO notification and so attempting to send a value to `FoilDefaultStorage` or `FoilDefaultStorageOptional`'s publisher after the storage is deallocated. ([#112](https://github.com/jessesquires/Foil/issues/112), [@nolanw](https://github.com/nolanw))
 
 5.1.1
 -----

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ NEXT
 
 - TBA
 
+5.1.2
+-----
+
+- Fix crash when receiving a KVO notification and so attempting to send a value to `FoilDefaultStorage` or `FoilDefaultStorageOptional`'s publisher after the storage is deallocated.
+
 5.1.1
 -----
 

--- a/Sources/FoilDefaultStorage.swift
+++ b/Sources/FoilDefaultStorage.swift
@@ -53,10 +53,11 @@ public struct FoilDefaultStorage<T: UserDefaultsSerializable> {
         // Publisher must be initialized after `registerDefault`,
         // because `fetch` assumes that `registerDefault` has been called before
         // and uses force unwrap
-        self._publisher = CurrentValueSubject<T, Never>(userDefaults.fetch(keyName))
+        let publisher = CurrentValueSubject<T, Never>(userDefaults.fetch(keyName))
+        self._publisher = publisher
 
-        self._observer = ObserverTrampoline(userDefaults: userDefaults, key: keyName) { [_publisher] in
-            _publisher.send(userDefaults.fetch(keyName))
+        self._observer = ObserverTrampoline(userDefaults: userDefaults, key: keyName) {
+            publisher.send(userDefaults.fetch(keyName))
         }
     }
 }

--- a/Sources/FoilDefaultStorage.swift
+++ b/Sources/FoilDefaultStorage.swift
@@ -55,7 +55,7 @@ public struct FoilDefaultStorage<T: UserDefaultsSerializable> {
         // and uses force unwrap
         self._publisher = CurrentValueSubject<T, Never>(userDefaults.fetch(keyName))
 
-        self._observer = ObserverTrampoline(userDefaults: userDefaults, key: keyName) { [unowned _publisher] in
+        self._observer = ObserverTrampoline(userDefaults: userDefaults, key: keyName) { [_publisher] in
             _publisher.send(userDefaults.fetch(keyName))
         }
     }

--- a/Sources/FoilDefaultStorageOptional.swift
+++ b/Sources/FoilDefaultStorageOptional.swift
@@ -51,9 +51,10 @@ public struct FoilDefaultStorageOptional<T: UserDefaultsSerializable> {
     public init(key keyName: String, userDefaults: UserDefaults = .standard) {
         self.key = keyName
         self._userDefaults = userDefaults
-        self._publisher = CurrentValueSubject<T?, Never>(userDefaults.fetchOptional(keyName))
-        self._observer = ObserverTrampoline(userDefaults: userDefaults, key: keyName) { [_publisher] in
-            _publisher.send(userDefaults.fetchOptional(keyName))
+        let publisher = CurrentValueSubject<T?, Never>(userDefaults.fetchOptional(keyName))
+        self._publisher = publisher
+        self._observer = ObserverTrampoline(userDefaults: userDefaults, key: keyName) {
+            publisher.send(userDefaults.fetchOptional(keyName))
         }
     }
 }

--- a/Sources/FoilDefaultStorageOptional.swift
+++ b/Sources/FoilDefaultStorageOptional.swift
@@ -52,7 +52,7 @@ public struct FoilDefaultStorageOptional<T: UserDefaultsSerializable> {
         self.key = keyName
         self._userDefaults = userDefaults
         self._publisher = CurrentValueSubject<T?, Never>(userDefaults.fetchOptional(keyName))
-        self._observer = ObserverTrampoline(userDefaults: userDefaults, key: keyName) { [unowned _publisher] in
+        self._observer = ObserverTrampoline(userDefaults: userDefaults, key: keyName) { [_publisher] in
             _publisher.send(userDefaults.fetchOptional(keyName))
         }
     }


### PR DESCRIPTION
A `FoilDefaultStorage{,Optional}` can deallocate while its `ObserverTrampoline` sticks around long enough to receive a KVO notification. (I'm not sure how.) When this happens, the attempt to dereference the captured `_publisher` crashes.

I don't know how to write a reliable test for the test suite, but I can reproduce the crash ~instantly with this code (e.g. pasted into a new test) in Xcode 16.0 beta 5 on an iPhone 8 running iOS 16.7.8 (as well as in iOS 15, 16, 17, and 18 simulators I have kicking around):

```swift
DispatchQueue.global().async {
    var storage: FoilDefaultStorageOptional<Int>?
    while true {
        storage = .init(key: "aloha")
    }
}
while true {
    UserDefaults.standard.set(Int.random(in: Int.min...Int.max), forKey: "aloha")
}
```

That's an admittedly silly test, but I'm seeing crashes in the wild attempting to dereference `_publisher`.

The obvious fix to me is to capture `_publisher` as either weak or strong, instead of unowned. A strong reference doesn't cause a cycle, so I chose it over the theoretically slower weak reference.