### PR TITLE
Convert XCTests to Swift tests

### DIFF
--- a/Tests/AsyncUtilities.swift
+++ b/Tests/AsyncUtilities.swift
@@ -1,0 +1,135 @@
+//
+//  Created by Jesse Squires
+//  https://www.jessesquires.com
+//
+//  Documentation
+//  https://jessesquires.github.io/Foil
+//
+//  GitHub
+//  https://github.com/jessesquires/Foil
+//
+//  Copyright © 2025-present Jesse Squires
+//
+
+import Combine
+import Foundation
+
+/// Extends AsyncSequence with a method to asynchronously map elements to a new array.
+/// This allows transformation of AsyncSequence elements with async operations.
+extension AsyncSequence where Self.Element: Sendable {
+    /// Asynchronously transforms each element of the sequence and collects results into an array.
+    ///
+    /// - Parameter transform: An async closure that transforms each element to type T.
+    /// - Returns: An array containing the transformed elements.
+    /// - Throws: Rethrows any errors thrown by the transform function or by the sequence iteration.
+    func asyncMap<T: Sendable>(
+        _ transform: (Element) async throws -> T
+    ) async rethrows -> [T] {
+        var values = [T]()
+
+        for try await element in self {
+            try await values.append(transform(element))
+        }
+
+        return values
+    }
+}
+
+/// An AsyncSequence adapter for Combine Publishers.
+/// Bridges between Combine's publisher pattern and Swift concurrency by wrapping
+/// a publisher in an AsyncSequence interface.
+struct AsyncPublisher<P> : AsyncSequence where P: Publisher, P.Failure == Never, P.Output: Sendable {
+    typealias Element = P.Output
+    typealias AsyncIterator = AsyncStream<P.Output>.AsyncIterator
+
+    var upstream : AnyPublisher<P.Output, Never>
+    
+    /// Creates a new AsyncPublisher that wraps the provided publisher.
+    ///
+    /// - Parameter upstream: The publisher to adapt to AsyncSequence.
+    init(_ upstream: AnyPublisher<P.Output, Never>) {
+        self.upstream = upstream
+    }
+
+    /// Creates an AsyncIterator that produces elements from the publisher.
+    /// Implements backpressure by requesting one value at a time.
+    ///
+    /// - Returns: An AsyncIterator that yields elements from the publisher.
+    func makeAsyncIterator() -> AsyncStream<Element>.AsyncIterator {
+        var subscription : Subscription?
+
+        let stream = AsyncStream<Element> { continuation in
+            let mySubscriber = AnySubscriber<Element, Never>(
+                receiveSubscription: { s in subscription = s; s.request(.max(1)) },
+                receiveValue: { continuation.yield($0); return .max(1) },
+                receiveCompletion:  { _ in continuation.finish(); subscription?.cancel() })
+            
+            self.upstream.receive(subscriber: mySubscriber)
+        }
+        
+        return stream.makeAsyncIterator()
+    }
+}
+
+/// Extends AnyPublisher with a property to access its values as an AsyncSequence.
+extension AnyPublisher where Failure == Never, Output: Sendable {
+    /// Provides access to publisher values as an AsyncSequence.
+    ///
+    /// - Note: This is a pre-iOS 15 alternative to the native `.values` property.
+    /// - Returns: An AsyncSequence that produces the publisher's values.
+    // TODO: Replace usage with `.values` once >= iOS 15 minimum target is adopted
+    var _values : AsyncPublisher<Self> {
+        AsyncPublisher<Self>(self)
+    }
+}
+
+/// An AsyncSequence adapter for NSObject.KeyValueObservingPublisher.
+/// Bridges between KVO publishers and Swift concurrency by wrapping
+/// a KVO publisher in an AsyncSequence interface.
+struct AsyncKVOPublisher<Object: NSObject, Value>: AsyncSequence where Value: Sendable {
+    typealias Element = Value
+    typealias AsyncIterator = AsyncStream<Value>.AsyncIterator
+
+    var upstream: NSObject.KeyValueObservingPublisher<Object, Value>
+    
+    /// Creates a new AsyncKVOPublisher that wraps the provided KVO publisher.
+    ///
+    /// - Parameter upstream: The KVO publisher to adapt to AsyncSequence.
+    init(upstream: NSObject.KeyValueObservingPublisher<Object, Value>) {
+        self.upstream = upstream
+    }
+
+    /// Creates an AsyncIterator that produces elements from the KVO publisher.
+    ///
+    /// - Returns: An AsyncIterator that yields elements from the KVO publisher.
+    func makeAsyncIterator() -> AsyncStream<Element>.AsyncIterator {
+        var cancellable: AnyCancellable?
+
+        let stream = AsyncStream<Element> { continuation in
+            cancellable = self.upstream
+                .sink(
+                    receiveCompletion: { _ in
+                        continuation.finish()
+                        cancellable?.cancel()
+                    },
+                    receiveValue: { value in
+                        continuation.yield(value)
+                    }
+                )
+        }
+        
+        return stream.makeAsyncIterator()
+    }
+}
+
+/// Extends NSObject.KeyValueObservingPublisher with a property to access its values as an AsyncSequence.
+extension NSObject.KeyValueObservingPublisher where Subject: NSObject, Value: Sendable {
+    /// Provides access to KVO publisher values as an AsyncSequence.
+    ///
+    /// - Note: This is a pre-iOS 15 alternative to the native `.values` property.
+    /// - Returns: An AsyncSequence that produces the KVO publisher's values.
+    // TODO: Replace usage with `.values` once >= iOS 15 minimum target is adopted
+    var _values: AsyncKVOPublisher<Subject, Value> {
+        AsyncKVOPublisher(upstream: self)
+    }
+}

--- a/Tests/Foil.xctestplan
+++ b/Tests/Foil.xctestplan
@@ -1,0 +1,25 @@
+{
+  "configurations" : [
+    {
+      "id" : "EB10D442-1A35-4A66-AB30-A347A8C8FC36",
+      "name" : "Configuration 1",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+    "testTimeoutsEnabled" : true
+  },
+  "testTargets" : [
+    {
+      "parallelizable" : false,
+      "target" : {
+        "containerPath" : "container:",
+        "identifier" : "FoilTests",
+        "name" : "FoilTests"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/Tests/IntegrationTests.swift
+++ b/Tests/IntegrationTests.swift
@@ -12,164 +12,177 @@
 //
 
 @testable import Foil
-import XCTest
+import Foundation
+import Testing
 
-final class IntegrationTests: XCTestCase {
 
-    let settings = TestSettings()
+@Suite("Integration tests")
+struct IntegrationTests {
 
-    override func setUpWithError() throws {
-        try super.setUpWithError()
-        TestSettings.reset()
-    }
+    let settings = TestSettings(suiteName: UUID().uuidString)
 
+    @Test
     func test_Integration_Bool() {
-        let defaultValue = self.settings.flag
-        XCTAssertTrue(defaultValue)
+        let defaultValue = settings.flag.wrappedValue
+        #expect(defaultValue)
 
-        self.settings.flag = false
-        XCTAssertFalse(TestSettings.store.fetch("flag"))
+        settings.flag.wrappedValue = false
+        #expect(settings.store.fetch("flag") == false)
     }
 
+    @Test
     func test_Integration_Int() {
-        let defaultValue = self.settings.count
-        XCTAssertEqual(defaultValue, 42)
+        let defaultValue = settings.count.wrappedValue
+        #expect(defaultValue == 42)
 
         let newValue = 666
-        self.settings.count = newValue
-        XCTAssertEqual(TestSettings.store.fetch("count"), newValue)
+        settings.count.wrappedValue = newValue
+        #expect(settings.store.fetch("count") == newValue)
     }
 
+    @Test
     func test_Integration_UInt() {
-        let defaultValue = self.settings.max
-        XCTAssertEqual(defaultValue, 42)
+        let defaultValue = settings.max.wrappedValue
+        #expect(defaultValue == 42)
 
         let newValue = UInt(666)
-        self.settings.max = newValue
-        XCTAssertEqual(TestSettings.store.fetch("max"), newValue)
+        settings.max.wrappedValue = newValue
+        #expect(settings.store.fetch("max") == newValue)
     }
 
+    @Test
     func test_Integration_Float() {
-        let defaultValue = self.settings.mean
-        XCTAssertEqual(defaultValue, 4.2)
+        let defaultValue = settings.mean.wrappedValue
+        #expect(defaultValue == 4.2)
 
         let newValue = Float(66.6)
-        self.settings.mean = newValue
-        XCTAssertEqual(TestSettings.store.fetch("mean"), newValue)
+        settings.mean.wrappedValue = newValue
+        #expect(settings.store.fetch("mean") == newValue)
     }
 
+    @Test
     func test_Integration_Double() {
-        let defaultValue = self.settings.average
-        XCTAssertEqual(defaultValue, 42.0)
+        let defaultValue = settings.average.wrappedValue
+        #expect(defaultValue == 42.0)
 
         let newValue = 6.66
-        self.settings.average = newValue
-        XCTAssertEqual(TestSettings.store.fetch("average"), newValue)
+        settings.average.wrappedValue = newValue
+        #expect(settings.store.fetch("average") == newValue)
     }
 
+    @Test
     func test_Integration_StringOptional() {
-        let defaultValue = self.settings.username
-        XCTAssertNil(defaultValue)
+        let defaultValue = settings.username.wrappedValue
+        #expect(defaultValue == nil)
 
         let newValue = "@jessesquires"
-        self.settings.username = newValue
-        XCTAssertEqual(TestSettings.store.fetch("username"), newValue)
+        settings.username.wrappedValue = newValue
+        #expect(settings.store.fetch("username") == newValue)
 
-        self.settings.username = nil
-        XCTAssertNil(TestSettings.store.fetchOptional("username") as String?)
+        settings.username.wrappedValue = nil
+        #expect(settings.store.fetchOptional("username") as String? == nil)
     }
 
+    @Test
     func test_Integration_URLOptional() {
-        let defaultValue = self.settings.website
-        XCTAssertNil(defaultValue)
+        let defaultValue = settings.website.wrappedValue
+        #expect(defaultValue == nil)
 
         let newValue = URL(string: "www.jessesquires.com")
-        self.settings.website = newValue
-        XCTAssertEqual(TestSettings.store.fetch("website"), newValue)
+        settings.website.wrappedValue = newValue
+        #expect(settings.store.fetch("website") == newValue)
 
-        self.settings.website = nil
-        XCTAssertNil(TestSettings.store.fetchOptional("website") as URL?)
+        settings.website.wrappedValue = nil
+        #expect(settings.store.fetchOptional("website") as URL? == nil)
     }
 
+    @Test
     func test_Integration_Date() {
-        let defaultValue = self.settings.timestamp
-        XCTAssertEqual(defaultValue, .distantPast)
+        let defaultValue = settings.timestamp.wrappedValue
+        #expect(defaultValue == .distantPast)
 
         let newValue = Date()
-        self.settings.timestamp = newValue
-        XCTAssertEqual(TestSettings.store.fetch("timestamp"), newValue)
+        settings.timestamp.wrappedValue = newValue
+        #expect(settings.store.fetch("timestamp") == newValue)
     }
 
+    @Test
     func test_Integration_DataOptional() {
-        let defaultValue = self.settings.data
-        XCTAssertNil(defaultValue)
+        let defaultValue = settings.data.wrappedValue
+        #expect(defaultValue == nil)
 
         let newValue = Data("text data".utf8)
-        self.settings.data = newValue
-        XCTAssertEqual(TestSettings.store.fetch("data"), newValue)
+        settings.data.wrappedValue = newValue
+        #expect(settings.store.fetch("data") == newValue)
 
-        self.settings.data = nil
-        XCTAssertNil(TestSettings.store.fetchOptional("data") as Data?)
+        settings.data.wrappedValue = nil
+        #expect(settings.store.fetchOptional("data") as Data? == nil)
     }
 
+    @Test
     func test_Integration_Array() {
-        let defaultValue = self.settings.list
-        XCTAssertEqual(defaultValue, [])
+        let defaultValue = settings.list.wrappedValue
+        #expect(defaultValue == [])
 
         let newValue = [6.66, 7.77, 8.88]
-        self.settings.list = newValue
-        XCTAssertEqual(TestSettings.store.fetch("list"), newValue)
+        settings.list.wrappedValue = newValue
+        #expect(settings.store.fetch("list") == newValue)
     }
 
+    @Test
     func test_Integration_Set() {
-        let defaultValue = self.settings.set
-        XCTAssertEqual(defaultValue, [1, 2, 3])
+        let defaultValue = settings.set.wrappedValue
+        #expect(defaultValue == [1, 2, 3])
 
         let newValue = Set([6, 77, 888])
-        self.settings.set = newValue
-        XCTAssertEqual(TestSettings.store.fetch("set"), newValue)
+        settings.set.wrappedValue = newValue
+        #expect(settings.store.fetch("set") == newValue)
     }
 
+    @Test
     func test_Integration_Dictionary() {
-        let defaultValue = self.settings.pairs
-        XCTAssertEqual(defaultValue, [:])
+        let defaultValue = settings.pairs.wrappedValue
+        #expect(defaultValue == [:])
 
         let newValue = ["six": 6, "seventy-seven": 77, "eight-hundred eighty eight": 888]
-        self.settings.pairs = newValue
-        XCTAssertEqual(TestSettings.store.fetch("pairs"), newValue)
+        settings.pairs.wrappedValue = newValue
+        #expect(settings.store.fetch("pairs") == newValue)
     }
 
+    @Test
     func test_Integration_RawRepresentable() {
-        let defaultValue = self.settings.fruit
-        XCTAssertEqual(defaultValue, .apple)
+        let defaultValue = settings.fruit.wrappedValue
+        #expect(defaultValue == .apple)
 
         let newValue = TestFruit.orange
-        self.settings.fruit = newValue
-        XCTAssertEqual(TestSettings.store.fetch("fruit"), newValue)
+        settings.fruit.wrappedValue = newValue
+        #expect(settings.store.fetch("fruit") == newValue)
     }
 
+    @Test
     func test_Integration_Custom_RawRepresentable() {
-        let defaultValue = self.settings.customRawRepresented
-        XCTAssert(defaultValue.rawValue.isEmpty)
+        let defaultValue = settings.customRawRepresented.wrappedValue
+        #expect(defaultValue.rawValue.isEmpty)
 
         var newValue = TestFruit.apple
-        self.settings.customRawRepresented[.key1] = newValue
-        XCTAssertEqual(self.settings.customRawRepresented[.key1], newValue)
+        settings.customRawRepresented.wrappedValue[.key1] = newValue
+        #expect(settings.customRawRepresented.wrappedValue[.key1] == newValue)
 
         newValue = TestFruit.orange
-        self.settings.customRawRepresented[.key2] = newValue
-        XCTAssertEqual(self.settings.customRawRepresented[.key2], newValue)
+        settings.customRawRepresented.wrappedValue[.key2] = newValue
+        #expect(settings.customRawRepresented.wrappedValue[.key2] == newValue)
 
         let expectedValue = ["key1": TestFruit.apple.rawValue, "key2": TestFruit.orange.rawValue]
-        XCTAssertEqual(TestSettings.store.fetch("customRawRepresented"), expectedValue)
+        #expect(settings.store.fetch("customRawRepresented") == expectedValue)
     }
 
+    @Test
     func test_Integration_Codable() {
-        let defaultValue = self.settings.user
-        XCTAssertNil(defaultValue)
+        let defaultValue = settings.user.wrappedValue
+        #expect(defaultValue == nil)
 
         let newValue = User(id: UUID(), name: "John Doe", highScore: 9_999, lastLogin: Date())
-        self.settings.user = newValue
-        XCTAssertEqual(self.settings.user, newValue)
+        settings.user.wrappedValue = newValue
+        #expect(settings.user.wrappedValue == newValue)
     }
 }

--- a/Tests/ObservationTests.swift
+++ b/Tests/ObservationTests.swift
@@ -11,102 +11,90 @@
 //  Copyright © 2021-present Jesse Squires
 //
 
-import Combine
 @testable import Foil
-import XCTest
+import Combine
+import Foundation
+import Testing
 
-let defaultTimeout = TimeInterval(3)
+@Suite("Observation tests")
+struct ObservationTests {
 
-final class ObservationTests: XCTestCase {
+    let settings = TestSettings(suiteName: UUID().uuidString)
 
-    var cancellable = Set<AnyCancellable>()
-
-    var observer: NSKeyValueObservation?
-
-    override func setUpWithError() throws {
-        try super.setUpWithError()
-        TestSettings.reset()
-    }
-
-    func test_Integration_ProjectedValue() {
-        let settings = TestSettings()
-        let expectation = self.expectation(description: #function)
+    @Test
+    func test_Integration_ProjectedValue() async {
+        let expectedInitialValue = 42.0
         let expectedValue = 1_000.0
-        var publishedValue: Double?
 
-        settings.$average
-            .sink { newValue in
-                publishedValue = newValue
-
-                // `receiveValue` in sink triggers twice:
-                // 1. with the initial value 42
-                // 2. when new value is set
-                if newValue == expectedValue {
-                    expectation.fulfill()
-                }
-            }
-            .store(in: &self.cancellable)
-
-        settings.average = expectedValue
-        self.wait(for: [expectation], timeout: defaultTimeout)
-
-        XCTAssertEqual(settings.average, publishedValue)
-    }
-
-    func test_Integration_ProjectedValue_ExternalChange() {
-        let settings = TestSettings()
-        let expectation = self.expectation(description: #function)
-        let expectedValue = 1_000.0
-        var publishedValue: Double?
-
-        settings.$average
-            .sink { newValue in
-                publishedValue = newValue
-
-                if newValue == expectedValue {
-                    expectation.fulfill()
-                }
-            }
-            .store(in: &self.cancellable)
-
-        type(of: settings).store.set(expectedValue, forKey: "average")
-        self.wait(for: [expectation], timeout: defaultTimeout)
-
-        XCTAssertEqual(settings.average, publishedValue)
-    }
-
-    func test_Integration_Publisher() {
-        let settings = TestSettings()
-        let expectation = self.expectation(description: #function)
-        var publishedValue: String?
-
-        settings
-            .publisher(for: \.userId, options: [.new])
-            .sink { newValue in
-                publishedValue = newValue
-                expectation.fulfill()
-            }
-            .store(in: &self.cancellable)
-
-        settings.userId = "test_publisher"
-        self.wait(for: [expectation], timeout: defaultTimeout)
-
-        XCTAssertEqual(settings.userId, publishedValue)
-    }
-
-    func test_Integration_KVO() {
-        let settings = TestSettings()
-        let expectation = self.expectation(description: #function)
-
-        self.observer = settings.observe(\.userId, options: [.new, .old]) { _, change in
-            guard let newValue = change.newValue else {
-                return
-            }
-            expectation.fulfill()
-            XCTAssertEqual(settings.userId, newValue)
+        let task = Task {
+            await settings.average
+                .projectedValue
+                ._values
+                .prefix(2)
+                .asyncMap { $0 }
         }
 
-        settings.userId = "test_kvo"
-        self.wait(for: [expectation], timeout: defaultTimeout)
+        settings.average.wrappedValue = expectedValue
+
+        let emittedValues = await task.value
+        #expect(emittedValues == [expectedInitialValue, expectedValue])
+    }
+
+    @Test
+    func test_Integration_ProjectedValue_ExternalChange() async {
+        let expectedInitialValue = 42.0
+        let expectedValue = 1_000.0
+
+        let task = Task {
+            await settings.average
+                .projectedValue
+                ._values
+                .prefix(2)
+                .asyncMap { $0 }
+        }
+
+        settings.store.set(expectedValue, forKey: "average")
+        let emittedValues = await task.value
+        #expect(emittedValues == [expectedInitialValue, expectedValue])
+    }
+
+    @Test
+    func test_Integration_Publisher() async {
+        let publishedValue = "test_publisher"
+
+        let task = Task {
+            await settings.publisher(for: \.userId)
+                ._values
+                .prefix(1)
+                .asyncMap { $0 }
+        }
+
+        settings.userId = publishedValue
+        let emittedValues = await task.value
+
+        #expect(emittedValues == [publishedValue])
+    }
+
+    @Test
+    func test_Integration_KVO() async {
+        let publishedValue = "test_kvo"
+        var observation: NSKeyValueObservation?
+
+        let stream = AsyncStream(String?.self) { continuation in
+            observation = settings.observe(\.userId, options: [.new, .old]) { _, change in
+                guard let newValue = change.newValue else {
+                    continuation.finish()
+                    return
+                }
+                continuation.yield(newValue)
+                continuation.finish()
+            }
+        }
+
+        settings.userId = publishedValue
+        let emittedValues = await stream.asyncMap { $0 }.first!
+
+        #expect(observation != nil)
+        #expect(emittedValues == publishedValue)
     }
 }

--- a/Tests/PropertyWrapperTests.swift
+++ b/Tests/PropertyWrapperTests.swift
@@ -12,330 +12,350 @@
 //
 
 @testable import Foil
-import XCTest
+import Foundation
+import Testing
 
-final class PropertyWrapperTests: XCTestCase {
+@Suite("Property wrapper tests")
+struct PropertyWrapperTests {
 
-    let domain = UUID().uuidString
-    lazy var testDefaults = UserDefaults.testSuite(name: self.domain)
+    let testDefaults: UserDefaults
 
-    override func tearDownWithError() throws {
-        try super.tearDownWithError()
-        self.testDefaults.reset(name: self.domain)
+    init() {
+        self.testDefaults = UserDefaults.testSuite(name: UUID().uuidString)
     }
 
+    @Test
     func test_WrappedValue_Bool() {
         let key = "key_\(#function)"
         let defaultValue = true
         var model = FoilDefaultStorage(wrappedValue: defaultValue, key: key, userDefaults: self.testDefaults)
 
-        XCTAssertEqual(self.testDefaults.fetch(key), defaultValue)
-        XCTAssertEqual(model.wrappedValue, defaultValue)
+        #expect(self.testDefaults.fetch(key) == defaultValue)
+        #expect(model.wrappedValue == defaultValue)
 
         let newValue = false
         model.wrappedValue = newValue
-        XCTAssertEqual(self.testDefaults.fetch(key), newValue)
-        XCTAssertEqual(model.wrappedValue, newValue)
+        #expect(self.testDefaults.fetch(key) == newValue)
+        #expect(model.wrappedValue == newValue)
     }
 
+    @Test
     func test_WrappedValue_Int() {
         let key = "key_\(#function)"
         let defaultValue = 42
         var model = FoilDefaultStorage(wrappedValue: defaultValue, key: key, userDefaults: self.testDefaults)
 
-        XCTAssertEqual(self.testDefaults.fetch(key), defaultValue)
-        XCTAssertEqual(model.wrappedValue, defaultValue)
+        #expect(self.testDefaults.fetch(key) == defaultValue)
+        #expect(model.wrappedValue == defaultValue)
 
         let newValue = 666
         model.wrappedValue = newValue
-        XCTAssertEqual(self.testDefaults.fetch(key), newValue)
-        XCTAssertEqual(model.wrappedValue, newValue)
+        #expect(self.testDefaults.fetch(key) == newValue)
+        #expect(model.wrappedValue == newValue)
     }
 
+    @Test
     func test_WrappedValue_UInt() {
         let key = "key_\(#function)"
         let defaultValue = UInt(42)
         var model = FoilDefaultStorage(wrappedValue: defaultValue, key: key, userDefaults: self.testDefaults)
 
-        XCTAssertEqual(self.testDefaults.fetch(key), defaultValue)
-        XCTAssertEqual(model.wrappedValue, defaultValue)
+        #expect(self.testDefaults.fetch(key) == defaultValue)
+        #expect(model.wrappedValue == defaultValue)
 
         let newValue = UInt(666)
         model.wrappedValue = newValue
-        XCTAssertEqual(self.testDefaults.fetch(key), newValue)
-        XCTAssertEqual(model.wrappedValue, newValue)
+        #expect(self.testDefaults.fetch(key) == newValue)
+        #expect(model.wrappedValue == newValue)
     }
 
+    @Test
     func test_WrappedValue_Float() {
         let key = "key_\(#function)"
         let defaultValue = Float(42.0)
         var model = FoilDefaultStorage(wrappedValue: defaultValue, key: key, userDefaults: self.testDefaults)
 
-        XCTAssertEqual(self.testDefaults.fetch(key), defaultValue)
-        XCTAssertEqual(model.wrappedValue, defaultValue)
+        #expect(self.testDefaults.fetch(key) == defaultValue)
+        #expect(model.wrappedValue == defaultValue)
 
         let newValue = Float(66.6)
         model.wrappedValue = newValue
-        XCTAssertEqual(self.testDefaults.fetch(key), newValue)
-        XCTAssertEqual(model.wrappedValue, newValue)
+        #expect(self.testDefaults.fetch(key) == newValue)
+        #expect(model.wrappedValue == newValue)
     }
 
+    @Test
     func test_WrappedValue_Double() {
         let key = "key_\(#function)"
         let defaultValue = Double(42.0)
         var model = FoilDefaultStorage(wrappedValue: defaultValue, key: key, userDefaults: self.testDefaults)
 
-        XCTAssertEqual(self.testDefaults.fetch(key), defaultValue)
-        XCTAssertEqual(model.wrappedValue, defaultValue)
+        #expect(self.testDefaults.fetch(key) == defaultValue)
+        #expect(model.wrappedValue == defaultValue)
 
         let newValue = Double(66.6)
         model.wrappedValue = newValue
-        XCTAssertEqual(self.testDefaults.fetch(key), newValue)
-        XCTAssertEqual(model.wrappedValue, newValue)
+        #expect(self.testDefaults.fetch(key) == newValue)
+        #expect(model.wrappedValue == newValue)
     }
 
+    @Test
     func test_WrappedValue_String() {
         let key = "key_\(#function)"
         let defaultValue = "default-value"
         var model = FoilDefaultStorage(wrappedValue: defaultValue, key: key, userDefaults: self.testDefaults)
 
-        XCTAssertEqual(self.testDefaults.fetch(key), defaultValue)
-        XCTAssertEqual(model.wrappedValue, defaultValue)
+        #expect(self.testDefaults.fetch(key) == defaultValue)
+        #expect(model.wrappedValue == defaultValue)
 
         let newValue = "new-value"
         model.wrappedValue = newValue
-        XCTAssertEqual(self.testDefaults.fetch(key), newValue)
-        XCTAssertEqual(model.wrappedValue, newValue)
+        #expect(self.testDefaults.fetch(key) == newValue)
+        #expect(model.wrappedValue == newValue)
     }
 
+    @Test
     func test_WrappedValue_URL() {
         let key = "key_\(#function)"
         let defaultValue = URL(string: "https://hexedbits.com")!
         var model = FoilDefaultStorage(wrappedValue: defaultValue, key: key, userDefaults: self.testDefaults)
 
-        XCTAssertEqual(self.testDefaults.fetch(key), defaultValue)
-        XCTAssertEqual(model.wrappedValue, defaultValue)
+        #expect(self.testDefaults.fetch(key) == defaultValue)
+        #expect(model.wrappedValue == defaultValue)
 
         let newValue = URL(string: "https://jessesquires.com")!
         model.wrappedValue = newValue
-        XCTAssertEqual(self.testDefaults.fetch(key), newValue)
-        XCTAssertEqual(model.wrappedValue, newValue)
+        #expect(self.testDefaults.fetch(key) == newValue)
+        #expect(model.wrappedValue == newValue)
     }
 
+    @Test
     func test_WrappedValue_Date() {
         let key = "key_\(#function)"
         let defaultValue = Date.distantPast
         var model = FoilDefaultStorage(wrappedValue: defaultValue, key: key, userDefaults: self.testDefaults)
 
-        XCTAssertEqual(self.testDefaults.fetch(key), defaultValue)
-        XCTAssertEqual(model.wrappedValue, defaultValue)
+        #expect(self.testDefaults.fetch(key) == defaultValue)
+        #expect(model.wrappedValue == defaultValue)
 
         let newValue = Date()
         model.wrappedValue = newValue
-        XCTAssertEqual(self.testDefaults.fetch(key), newValue)
-        XCTAssertEqual(model.wrappedValue, newValue)
+        #expect(self.testDefaults.fetch(key) == newValue)
+        #expect(model.wrappedValue == newValue)
     }
 
+    @Test
     func test_WrappedValue_Data() {
         let key = "key_\(#function)"
         let defaultValue = Data("default-data".utf8)
         var model = FoilDefaultStorage(wrappedValue: defaultValue, key: key, userDefaults: self.testDefaults)
 
-        XCTAssertEqual(self.testDefaults.fetch(key), defaultValue)
-        XCTAssertEqual(model.wrappedValue, defaultValue)
+        #expect(self.testDefaults.fetch(key) == defaultValue)
+        #expect(model.wrappedValue == defaultValue)
 
         let newValue = Data("new-data".utf8)
         model.wrappedValue = newValue
-        XCTAssertEqual(self.testDefaults.fetch(key), newValue)
-        XCTAssertEqual(model.wrappedValue, newValue)
+        #expect(self.testDefaults.fetch(key) == newValue)
+        #expect(model.wrappedValue == newValue)
     }
 
+    @Test
     func test_WrappedValue_Array() {
         let key = "key_\(#function)"
         let defaultValue = [1, 2, 3]
         var model = FoilDefaultStorage(wrappedValue: defaultValue, key: key, userDefaults: self.testDefaults)
 
-        XCTAssertEqual(self.testDefaults.fetch(key), defaultValue)
-        XCTAssertEqual(model.wrappedValue, defaultValue)
+        #expect(self.testDefaults.fetch(key) == defaultValue)
+        #expect(model.wrappedValue == defaultValue)
 
         let newValue = [4, 5, 6]
         model.wrappedValue = newValue
-        XCTAssertEqual(self.testDefaults.fetch(key), newValue)
-        XCTAssertEqual(model.wrappedValue, newValue)
+        #expect(self.testDefaults.fetch(key) == newValue)
+        #expect(model.wrappedValue == newValue)
     }
 
+    @Test
     func test_WrappedValue_Set() {
         let key = "key_\(#function)"
         let defaultValue = Set(["one", "two", "three"])
         var model = FoilDefaultStorage(wrappedValue: defaultValue, key: key, userDefaults: self.testDefaults)
 
-        XCTAssertEqual(self.testDefaults.fetch(key), defaultValue)
-        XCTAssertEqual(model.wrappedValue, defaultValue)
+        #expect(self.testDefaults.fetch(key) == defaultValue)
+        #expect(model.wrappedValue == defaultValue)
 
         let newValue = Set(["four", "five", "size"])
         model.wrappedValue = newValue
-        XCTAssertEqual(self.testDefaults.fetch(key), newValue)
-        XCTAssertEqual(model.wrappedValue, newValue)
+        #expect(self.testDefaults.fetch(key) == newValue)
+        #expect(model.wrappedValue == newValue)
     }
 
+    @Test
     func test_WrappedValue_Dictionary() {
         let key = "key_\(#function)"
         let defaultValue = ["key1": 42.0,
                             "key2": 4.2]
         var model = FoilDefaultStorage(wrappedValue: defaultValue, key: key, userDefaults: self.testDefaults)
 
-        XCTAssertEqual(self.testDefaults.fetch(key), defaultValue)
-        XCTAssertEqual(model.wrappedValue, defaultValue)
+        #expect(self.testDefaults.fetch(key) == defaultValue)
+        #expect(model.wrappedValue == defaultValue)
 
         let newValue = ["key3": 0.42]
         model.wrappedValue = newValue
-        XCTAssertEqual(self.testDefaults.fetch(key), newValue)
-        XCTAssertEqual(model.wrappedValue, newValue)
+        #expect(self.testDefaults.fetch(key) == newValue)
+        #expect(model.wrappedValue == newValue)
     }
 
+    @Test
     func test_WrappedValue_RawRepresentable() {
         let key = "key_\(#function)"
         let defaultValue = TestFruit.apple
         var model = FoilDefaultStorage(wrappedValue: defaultValue, key: key, userDefaults: self.testDefaults)
 
-        XCTAssertEqual(self.testDefaults.fetch(key), defaultValue)
-        XCTAssertEqual(model.wrappedValue, defaultValue)
+        #expect(self.testDefaults.fetch(key) == defaultValue)
+        #expect(model.wrappedValue == defaultValue)
 
         let newValue = TestFruit.banana
         model.wrappedValue = newValue
-        XCTAssertEqual(self.testDefaults.fetch(key), newValue)
-        XCTAssertEqual(model.wrappedValue, newValue)
+        #expect(self.testDefaults.fetch(key) == newValue)
+        #expect(model.wrappedValue == newValue)
     }
 
+    @Test
     func test_WrappedValue_IntOptional() {
         let key = "key_\(#function)"
         var model = FoilDefaultStorageOptional<Int>(key: key, userDefaults: self.testDefaults)
 
         let defaultValue: Int? = self.testDefaults.fetchOptional(key)
-        XCTAssertNil(defaultValue)
-        XCTAssertNil(model.wrappedValue)
+        #expect(defaultValue == nil)
+        #expect(model.wrappedValue == nil)
 
         let newValue = 666
         model.wrappedValue = newValue
-        XCTAssertEqual(self.testDefaults.fetch(key), newValue)
-        XCTAssertEqual(model.wrappedValue, newValue)
+        #expect(self.testDefaults.fetch(key) == newValue)
+        #expect(model.wrappedValue == newValue)
 
         model.wrappedValue = nil
-        XCTAssertNil(model.wrappedValue)
+        #expect(model.wrappedValue == nil)
 
         let fetchedValue: Int? = self.testDefaults.fetchOptional(key)
-        XCTAssertNil(fetchedValue)
+        #expect(fetchedValue == nil)
     }
 
+    @Test
     func test_WrappedValue_StringOptional() {
         let key = "key_\(#function)"
         var model = FoilDefaultStorageOptional<String>(key: key, userDefaults: self.testDefaults)
 
         let defaultValue: String? = self.testDefaults.fetchOptional(key)
-        XCTAssertNil(defaultValue)
-        XCTAssertNil(model.wrappedValue)
+        #expect(defaultValue == nil)
+        #expect(model.wrappedValue == nil)
 
         let newValue = "some text"
         model.wrappedValue = newValue
-        XCTAssertEqual(self.testDefaults.fetch(key), newValue)
-        XCTAssertEqual(model.wrappedValue, newValue)
+        #expect(self.testDefaults.fetch(key) == newValue)
+        #expect(model.wrappedValue == newValue)
 
         model.wrappedValue = nil
-        XCTAssertNil(model.wrappedValue)
+        #expect(model.wrappedValue == nil)
 
         let fetchedValue: String? = self.testDefaults.fetchOptional(key)
-        XCTAssertNil(fetchedValue)
+        #expect(fetchedValue == nil)
     }
 
+    @Test
     func test_WrappedValue_URLOptional() {
         let key = "key_\(#function)"
         var model = FoilDefaultStorageOptional<URL>(key: key, userDefaults: self.testDefaults)
 
         let defaultValue: URL? = self.testDefaults.fetchOptional(key)
-        XCTAssertNil(defaultValue)
-        XCTAssertNil(model.wrappedValue)
+        #expect(defaultValue == nil)
+        #expect(model.wrappedValue == nil)
 
         let newValue = URL(string: "www.jessesquires.com")
         model.wrappedValue = newValue
-        XCTAssertEqual(self.testDefaults.fetch(key), newValue)
-        XCTAssertEqual(model.wrappedValue, newValue)
+        #expect(self.testDefaults.fetch(key) == newValue)
+        #expect(model.wrappedValue == newValue)
 
         model.wrappedValue = nil
-        XCTAssertNil(model.wrappedValue)
+        #expect(model.wrappedValue == nil)
 
         let fetchedValue: URL? = self.testDefaults.fetchOptional(key)
-        XCTAssertNil(fetchedValue)
+        #expect(fetchedValue == nil)
     }
 
+    @Test
     func test_WrappedValue_DateOptional() {
         let key = "key_\(#function)"
         var model = FoilDefaultStorageOptional<Date>(key: key, userDefaults: self.testDefaults)
 
         let defaultValue: Date? = self.testDefaults.fetchOptional(key)
-        XCTAssertNil(defaultValue)
-        XCTAssertNil(model.wrappedValue)
+        #expect(defaultValue == nil)
+        #expect(model.wrappedValue == nil)
 
         let newValue = Date()
         model.wrappedValue = newValue
-        XCTAssertEqual(self.testDefaults.fetch(key), newValue)
-        XCTAssertEqual(model.wrappedValue, newValue)
+        #expect(self.testDefaults.fetch(key) == newValue)
+        #expect(model.wrappedValue == newValue)
 
         model.wrappedValue = nil
-        XCTAssertNil(model.wrappedValue)
+        #expect(model.wrappedValue == nil)
 
         let fetchedValue: Date? = self.testDefaults.fetchOptional(key)
-        XCTAssertNil(fetchedValue)
+        #expect(fetchedValue == nil)
     }
 
-    // swiftlint:disable discouraged_optional_collection
+
+    @Test// swiftlint:disable discouraged_optional_collection
     func test_WrappedValue_DictionaryOptional() {
         let key = "key_\(#function)"
         var model = FoilDefaultStorageOptional<[String: TestFruit]>(key: key, userDefaults: self.testDefaults)
 
         let defaultValue: [String: TestFruit]? = self.testDefaults.fetchOptional(key)
-        XCTAssertNil(defaultValue)
-        XCTAssertNil(model.wrappedValue)
+        #expect(defaultValue == nil)
+        #expect(model.wrappedValue == nil)
 
         let newValue = ["key1": TestFruit.apple, "key2": .orange]
         model.wrappedValue = newValue
-        XCTAssertEqual(self.testDefaults.fetch(key), newValue)
-        XCTAssertEqual(model.wrappedValue, newValue)
+        #expect(self.testDefaults.fetch(key) == newValue)
+        #expect(model.wrappedValue == newValue)
 
         model.wrappedValue = nil
-        XCTAssertNil(model.wrappedValue)
+        #expect(model.wrappedValue == nil)
 
         let fetchedValue: [String: TestFruit]? = self.testDefaults.fetchOptional(key)
-        XCTAssertNil(fetchedValue)
+        #expect(fetchedValue == nil)
     }
     // swiftlint:enable discouraged_optional_collection
 
+    @Test
     func test_WrappedValue_MismatchedOptional() {
         let key = "key_\(#function)"
         let model = FoilDefaultStorageOptional<Date>(key: key, userDefaults: self.testDefaults)
         testDefaults.save("not-a-date", for: key)
 
         let defaultValue: Date? = self.testDefaults.fetchOptional(key)
-        XCTAssertNil(defaultValue)
-        XCTAssertNil(model.wrappedValue)
+        #expect(defaultValue == nil)
+        #expect(model.wrappedValue == nil)
     }
 
+    @Test
     func test_WrappedValue_Codable_Optional() {
         let key = "key_\(#function)"
         var model = FoilDefaultStorageOptional<User>(key: key, userDefaults: self.testDefaults)
 
         let defaultValue: User? = self.testDefaults.fetchOptional(key)
-        XCTAssertNil(defaultValue)
-        XCTAssertNil(model.wrappedValue)
+        #expect(defaultValue == nil)
+        #expect(model.wrappedValue == nil)
 
         let newValue = User(id: UUID(), name: "John Doe", highScore: 9_000, lastLogin: Date())
         model.wrappedValue = newValue
-        XCTAssertEqual(self.testDefaults.fetch(key), newValue)
-        XCTAssertEqual(model.wrappedValue, newValue)
+        #expect(self.testDefaults.fetch(key) == newValue)
+        #expect(model.wrappedValue == newValue)
 
         model.wrappedValue = nil
-        XCTAssertNil(model.wrappedValue)
+        #expect(model.wrappedValue == nil)
 
         let fetchedValue: User? = self.testDefaults.fetchOptional(key)
-        XCTAssertNil(fetchedValue)
+        #expect(fetchedValue == nil)
     }
 }

--- a/Tests/TestSettings.swift
+++ b/Tests/TestSettings.swift
@@ -41,60 +41,58 @@ struct User: Hashable, Codable, UserDefaultsSerializable {
 }
 
 final class TestSettings: NSObject, @unchecked Sendable {
-    static let suiteName = UUID().uuidString
+    let suiteName: String
+    let store: UserDefaults
 
-    nonisolated(unsafe) static let store = UserDefaults.testSuite(name: suiteName)
+    var flag: FoilDefaultStorage<Bool>
+    var count: FoilDefaultStorage<Int>
+    var max: FoilDefaultStorage<UInt>
+    var mean: FoilDefaultStorage<Float>
+    var average: FoilDefaultStorage<Double>
+    var username: FoilDefaultStorageOptional<String>
+    var website: FoilDefaultStorageOptional<URL>
+    var timestamp: FoilDefaultStorage<Date>
+    var data: FoilDefaultStorageOptional<Data>
+    var list: FoilDefaultStorage<Array<Double>>
+    var set: FoilDefaultStorage<Set<Int>>
+    var pairs: FoilDefaultStorage<[String:Int]>
+    var fruit: FoilDefaultStorage<TestFruit>
+    var customRawRepresented: FoilDefaultStorage<TestCustomRepresented>
+    var _userId: FoilDefaultStorageOptional<String>
+    @objc dynamic var userId: String? {
+        get { _userId.wrappedValue }
+        set { _userId.wrappedValue = newValue }
+    }
+    var user: FoilDefaultStorageOptional<User>
 
-    // swiftlint:disable:next type_contents_order
-    static func reset() {
-        Self.store.reset(name: Self.suiteName)
+    init(suiteName: String) {
+        self.suiteName = suiteName
+        self.store = UserDefaults.testSuite(name: suiteName)
+
+        self.flag = .init(wrappedValue: true, key: "flag", userDefaults: store)
+        self.count = .init(wrappedValue: 42, key: "count", userDefaults: store)
+        self.max = .init(wrappedValue: UInt(42), key: "max", userDefaults: store)
+        self.mean = .init(wrappedValue: Float(4.2), key: "mean", userDefaults: store)
+        self.average = .init(wrappedValue: Double(42.0), key: "average", userDefaults: store)
+        self.username = .init(key: "username", userDefaults: store)
+        self.website = .init(key: "website", userDefaults: store)
+        self.timestamp = .init(wrappedValue: Date.distantPast, key: "timestamp", userDefaults: store)
+        self.data = .init(key: "data", userDefaults: store)
+        self.list = .init(wrappedValue: [Double](), key: "list", userDefaults: store)
+        self.set = .init(wrappedValue:  Set([1, 2, 3]), key: "set", userDefaults: store)
+        self.pairs = .init(wrappedValue: [String: Int](), key: "pairs", userDefaults: store)
+        self.fruit = .init(wrappedValue: TestFruit.apple, key: "fruit", userDefaults: store)
+        self.customRawRepresented = FoilDefaultStorage(
+            wrappedValue: TestCustomRepresented(rawValue: [:]),
+            key: "customRawRepresented",
+            userDefaults: store
+        )
+        self._userId =  .init(key: "userId", userDefaults: store)
+        self.user = .init(key: "user", userDefaults: store)
     }
 
-    @FoilDefaultStorage(key: "flag", userDefaults: store)
-    var flag = true
-
-    @FoilDefaultStorage(key: "count", userDefaults: store)
-    var count = 42
-
-    @FoilDefaultStorage(key: "max", userDefaults: store)
-    var max = UInt(42)
-
-    @FoilDefaultStorage(key: "mean", userDefaults: store)
-    var mean = Float(4.2)
-
-    @FoilDefaultStorage(key: "average", userDefaults: store)
-    var average = 42.0
-
-    @FoilDefaultStorageOptional(key: "username", userDefaults: store)
-    var username: String?
-
-    @FoilDefaultStorageOptional(key: "website", userDefaults: store)
-    var website: URL?
-
-    @FoilDefaultStorage(key: "timestamp", userDefaults: store)
-    var timestamp = Date.distantPast
-
-    @FoilDefaultStorageOptional(key: "data", userDefaults: store)
-    var data: Data?
-
-    @FoilDefaultStorage(key: "list", userDefaults: store)
-    var list = [Double]()
-
-    @FoilDefaultStorage(key: "set", userDefaults: store)
-    var set = Set([1, 2, 3])
-
-    @FoilDefaultStorage(key: "pairs", userDefaults: store)
-    var pairs = [String: Int]()
-
-    @FoilDefaultStorage(key: "fruit", userDefaults: store)
-    var fruit = TestFruit.apple
-
-    @FoilDefaultStorage(key: "customRawRepresented", userDefaults: store)
-    var customRawRepresented = TestCustomRepresented(rawValue: [:])
-
-    @FoilDefaultStorageOptional(key: "userId", userDefaults: store)
-    @objc dynamic var userId: String?
-
-    @FoilDefaultStorageOptional(key: "user", userDefaults: store)
-    var user: User?
+    // swiftlint:disable:next type_contents_order
+    func reset() {
+        store.reset(name: suiteName)
+    }
 }


### PR DESCRIPTION
Issue #107 :black_heart:

## Describe your changes

Converts XCTest based unit tests to use the Swift Testing framework and adds some test utilities for bridging between combine and async streams. 
